### PR TITLE
Added check and message for X being misused as *

### DIFF
--- a/src/compare.js
+++ b/src/compare.js
@@ -19,6 +19,21 @@ KAS.compare = function(expr1, expr2, options) {
         options = defaults;
     }
 
+    var xUsedAsMultOp = function() {
+        var vars = expr1.getVars() + expr2.getVars();
+        if (!_.contains(vars.toLowerCase(),"x"))
+            return false;
+        var replace = function(expr) {
+            var replacedStr = expr.print().replace(/.x./gi,"*");
+            return KAS.parse(replacedStr, options);
+        };
+        var testPairs = [[replace(expr1),expr2], [replace(expr2),expr1]];
+        return _.some(testPairs, function(pair) {
+            var x =  pair[0].parsed && pair[0].expr.compare(pair[1]);
+            return pair[0].parsed && pair[0].expr.compare(pair[1]);
+        });
+    };
+
     // variable check
     var vars = expr1.sameVars(expr2);
     if (!vars.equal) {
@@ -26,12 +41,19 @@ KAS.compare = function(expr1, expr2, options) {
         if (vars.equalIgnoringCase) {
             message = "Some of your variables are in the wrong case (upper vs. lower).";
         }
+        else if (xUsedAsMultOp()) {
+            message = "Use *, not x, for multiplication.";
+        }
         return {equal: false, message: message};
     }
 
     // semantic check
     if (!expr1.compare(expr2)) {
-        return {equal: false, message: null};
+        message = null;
+        if (xUsedAsMultOp()) {
+            message = "Use *, not x, for multiplication.";
+        }
+        return {equal: false, message: message};
     }
 
     // syntactic check

--- a/test.html
+++ b/test.html
@@ -1234,6 +1234,22 @@
         isSimplified("y=(2x+2)/(x+1)", false);
     });
 
+    var isMisusingX = function(input1, input2, expectedResult) {
+        if (expectedResult === undefined) expectedResult = true;
+        var result = KAS.compare(parse(input1), parse(input2));
+        var misuseMsg = "Use *, not x, for multiplication.";
+        var message = input1 + " or " + input2;
+        message +=  (expectedResult ? " is " : " is NOT ") + "misusing X.";
+        ok(result.message === misuseMsg || !expectedResult, message);
+    }
+
+    test("isMisusingX", function() {
+        isMisusingX("2*3", "2x3");
+        isMisusingX("2x-3", "2*-3");
+        isMisusingX("2*3", "2*3", false);
+        isMisusingX("2*3x", "2*3x", false);
+    });
+
 })(KAS);
 </script>
 


### PR DESCRIPTION
Submitting this as a result of @spicyj's feedback from https://github.com/Khan/khan-exercises/pull/71829

The code's a little more complicated compared to the khan-exercises pull request thanks to some information that's not accessible in KAS (like the original input string and which side is the "solution").

A way to get back to that simpler implementation would be to just have a KAS.xUsedAsMultOp function that takes the parameters the old function took, but to me it looks like the "right thing" is to just have KAS.compare spit out a new message.

N.B.: There are two checks, one after sameVars failure, another after expr.compare failure.  This is because expressions that match the check can go down either path.
