### PR TITLE
jison 0.4.15 generates a radically different parser and breaks the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "underscore": "~1.5.1"
   },
   "devDependencies": {
-    "jison": "~0.4.4",
+    "jison": "0.4.13",
     "qunit": "~0.5.16",
     "grunt": "~0.4.0",
     "grunt-contrib-concat": "~0.1.3",


### PR DESCRIPTION
Doing `npm install` or `npm update` right now will update jison for 0.4.15.  The parser that this version generates is quite different and breaks KAS.  I pegged the version to 0.4.13 which was the version listed in parser.js.
