### PR TITLE
Fix Pow.eval for Float exponents

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1422,6 +1422,8 @@ _.extend(Pow.prototype, {
                     var sign = (oddNumerator) ? -1 : 1;
                     return sign * Math.pow(-1 * evaledBase, evaledExp);
                 }
+            } else if (simplifiedExp instanceof Float) {
+                return -1 * Math.pow(-evaledBase, evaledExp);
             }
         }
         return Math.pow(evaledBase, evaledExp);


### PR DESCRIPTION
Negative numbers with non-integer exponents return NaN using `Math.pow`.  The fix for this seems to have already been applied for the Rationals but not for the Floats.  This can be seen when checking equality for `x^(3/5)` and `x^0.6`.