### PR TITLE
Change trigonometric evaluation strategy

### DIFF
--- a/kas.js
+++ b/kas.js
@@ -2254,7 +2254,7 @@ _.extend(Mul.prototype, {
     codegen: function() {
         return _.map(this.terms, function(term) {
             return "(" + term.codegen() + ")";
-        }).join(" * ") || "0";
+        }).join(" * ") || "1";
     },
 
     print: function() {
@@ -3431,50 +3431,85 @@ _.extend(Log, {
 function Trig(type, arg) { this.type = type; this.arg = arg; }
 Trig.prototype = new Expr();
 
+Trig.shifted = {
+    sin: function(arg) {
+        var region = Math.round(arg / Math.PI);  
+        if (region % 2 == 0) {
+            var shiftedArg = arg - region * Math.PI;
+        } else {
+            var shiftedArg = region * Math.PI - arg;
+        }
+        return Math.sin(shiftedArg);
+    },
+
+    cos: function (arg) {
+        var region = Math.round(arg / Math.PI + 1/2);
+        if (region % 2 == 0) {
+            var shiftedArg = region * Math.PI - arg - Math.PI/2;
+        } else {
+            var shiftedArg = arg + Math.PI/2 - region * Math.PI;
+        }
+        return -Math.sin(shiftedArg);
+    },
+
+    tan: function (arg) { 
+        return Trig.shifted.sin(arg) / Trig.shifted.cos(arg); 
+    },
+    csc: function (arg) {
+        return 1 / Trig.shifted.sin(arg);
+    },
+    sec: function (arg) {
+        return 1 / Trig.shifted.cos(arg);
+    },
+    cot: function (arg) {
+        return Trig.shifted.cos(arg) / Trig.shifted.sin(arg);
+    }
+};
+
 _.extend(Trig.prototype, {
     func: Trig,
     args: function() { return [this.type, this.arg]; },
 
     functions: {
         sin: {
-            eval: Math.sin,
-            codegen: "Math.sin((",
+            eval: Trig.shifted.sin,
+            codegen: "KAS.Trig.shifted.sin((",
             tex: "\\sin",
             expand: function() { return this; }
         },
         cos: {
-            eval: Math.cos,
-            codegen: "Math.cos((",
+            eval: Trig.shifted.cos,
+            codegen: "KAS.Trig.shifted.cos((",
             tex: "\\cos",
             expand: function() { return this; }
         },
         tan: {
-            eval: Math.tan,
-            codegen: "Math.tan((",
+            eval: Trig.shifted.tan,
+            codegen: "KAS.Trig.shifted.tan((",
             tex: "\\tan",
             expand: function() {
                 return Mul.handleDivide(Trig.sin(this.arg), Trig.cos(this.arg));
             }
         },
         csc: {
-            eval: function(arg) { return 1 / Math.sin(arg); },
-            codegen: "(1/Math.sin(",
+            eval: Trig.shifted.csc,
+            codegen: "KAS.Trig.shifted.csc((",
             tex: "\\csc",
             expand: function() {
                 return Mul.handleDivide(Num.One, Trig.sin(this.arg));
             }
         },
         sec: {
-            eval: function(arg) { return 1 / Math.cos(arg); },
-            codegen: "(1/Math.cos(",
+            eval: Trig.shifted.sec,
+            codegen: "KAS.Trig.shifted.sec((",
             tex: "\\sec",
             expand: function() {
                 return Mul.handleDivide(Num.One, Trig.cos(this.arg));
             }
         },
         cot: {
-            eval: function(arg) { return 1 / Math.tan(arg); },
-            codegen: "(1/Math.tan(",
+            eval: Trig.shifted.cot,
+            codegen: "KAS.Trig.shifted.cot((",
             tex: "\\cot",
             expand: function() {
                 return Mul.handleDivide(Trig.cos(this.arg), Trig.sin(this.arg));

--- a/shifted_trig_test.html
+++ b/shifted_trig_test.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>KAS shifted trigonometry tests</title>
+
+    <!-- Include QUnit -->
+    <link rel="stylesheet" href="node_modules/qunit/support/qunit/qunit/qunit.css" type="text/css" media="screen">
+    <script src="node_modules/qunit/support/qunit/qunit/qunit.js"></script>
+    <script src="node_modules/qunit/support/qunit/addons/close-enough/qunit-close-enough.js"></script>
+
+    <!-- Include Underscore -->
+    <script src="node_modules/underscore/underscore.js"></script>
+
+    <!-- Include KAS -->
+    <script src="src/parser.js"></script>
+    <script src="src/unitparser.js"></script>
+    <script src="src/nodes.js"></script>
+    <script src="src/compare.js"></script>
+</head>
+<body>
+
+<h1 id="qunit-header">KAS shifted trigonometry tests</h1>
+<h2 id="qunit-banner"></h2>
+<div id="qunit-testrunner-toolbar"></div>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+
+<div id="qunit-fixture">
+    <div id="solutionarea">
+    </div>
+    <div class="problem">
+    </div>
+</div>
+
+<script type="text/javascript">
+(function(KAS) {
+    var shiftedSin = KAS.Trig.shifted.sin;
+    var shiftedCos = KAS.Trig.shifted.cos;
+    var shiftedTan = KAS.Trig.shifted.tan;
+
+    // Here's a list of benchmark values of sine every pi/60 radians in [0, 2pi]
+    // These were calculated in sympy.
+    var SIN_VALUES = 
+        [0, 0.052335956242943833, 0.10452846326765347, 0.15643446504023087, 0.20791169081775934, 0.25881904510252076, 0.30901699437494742, 0.35836794954530027, 0.40673664307580021, 0.45399049973954679, 0.50000000000000000, 0.54463903501502708, 0.58778525229247313, 0.62932039104983745, 0.66913060635885821, 0.70710678118654752, 0.74314482547739424, 0.77714596145697088, 0.80901699437494742, 0.83867056794542403, 0.86602540378443865, 0.89100652418836786, 0.91354545764260090, 0.93358042649720175, 0.95105651629515357, 0.96592582628906829, 0.97814760073380564, 0.98768834059513773, 0.99452189536827334, 0.99862953475457387, 1.0000000000000000, 0.99862953475457387, 0.99452189536827334, 0.98768834059513773, 0.97814760073380564, 0.96592582628906829, 0.95105651629515357, 0.93358042649720175, 0.91354545764260090, 0.89100652418836786, 0.86602540378443865, 0.83867056794542403, 0.80901699437494742, 0.77714596145697088, 0.74314482547739424, 0.70710678118654752, 0.66913060635885821, 0.62932039104983745, 0.58778525229247313, 0.54463903501502708, 0.50000000000000000, 0.45399049973954679, 0.40673664307580021, 0.35836794954530027, 0.30901699437494742, 0.25881904510252076, 0.20791169081775934, 0.15643446504023087, 0.10452846326765347, 0.052335956242943833, 0, -0.052335956242943833, -0.10452846326765347, -0.15643446504023087, -0.20791169081775934, -0.25881904510252076, -0.30901699437494742, -0.35836794954530027, -0.40673664307580021, -0.45399049973954679, -0.50000000000000000, -0.54463903501502708, -0.58778525229247313, -0.62932039104983745, -0.66913060635885821, -0.70710678118654752, -0.74314482547739424, -0.77714596145697088, -0.80901699437494742, -0.83867056794542403, -0.86602540378443865, -0.89100652418836786, -0.91354545764260090, -0.93358042649720175, -0.95105651629515357, -0.96592582628906829, -0.97814760073380564, -0.98768834059513773, -0.99452189536827334, -0.99862953475457387, -1.0000000000000000, -0.99862953475457387, -0.99452189536827334, -0.98768834059513773, -0.97814760073380564, -0.96592582628906829, -0.95105651629515357, -0.93358042649720175, -0.91354545764260090, -0.89100652418836786, -0.86602540378443865, -0.83867056794542403, -0.80901699437494742, -0.77714596145697088, -0.74314482547739424, -0.70710678118654752, -0.66913060635885821, -0.62932039104983745, -0.58778525229247313, -0.54463903501502708, -0.50000000000000000, -0.45399049973954679, -0.40673664307580021, -0.35836794954530027, -0.30901699437494742, -0.25881904510252076, -0.20791169081775934, -0.15643446504023087, -0.10452846326765347, -0.052335956242943833]
+
+    // FULL_PERIOD satisfies SIN_VALUES[i] == sin(2i/FULL_PERIOD*pi)
+    // i.e. How many samples in 2pi?
+    var FULL_PERIOD = SIN_VALUES.length;
+    var HALF_PERIOD = FULL_PERIOD / 2;
+    var QUARTER_PER = FULL_PERIOD / 4;
+
+    // Here are some max precision benchmark values for tangent.
+    var TAN_VALUES = 
+        [NaN, -19.08113668772821, -9.514364454222585, -6.313751514675043, 
+         -4.704630109478454, -3.732050807568877, -3.077683537175253,  
+         -2.605089064693802, -2.246036773904216, -1.962610505505151,
+         -1.732050807568877,  -1.539864963814583, -1.376381920471174, 
+         -1.234897156535051, -1.110612514829193,  -1.000000000000000, 
+         -0.9004040442978399, -0.8097840331950071,  -0.7265425280053609, 
+         -0.6494075931975106, -0.5773502691896258,  -0.5095254494944288, 
+         -0.4452286853085362, -0.3838640350354158,  -0.3249196962329063, 
+         -0.2679491924311227, -0.2125565616700221,  -0.1583844403245363, 
+         -0.1051042352656765, -0.05240777928304120,  0, 0.05240777928304120, 
+         0.1051042352656765, 0.1583844403245363,  0.2125565616700221, 
+         0.2679491924311227, 0.3249196962329063, 0.3838640350354158, 
+         0.4452286853085362, 0.5095254494944288,  0.5773502691896258,
+        0.6494075931975106, 0.7265425280053609,  0.8097840331950071, 
+        0.9004040442978399, 1.000000000000000,  1.110612514829193, 
+        1.234897156535051, 1.376381920471174, 1.539864963814583, 1.732050807568877, 
+        1.962610505505151,  2.246036773904216, 2.605089064693802, 3.077683537175253,
+        3.732050807568877, 4.704630109478454, 6.313751514675043,  9.514364454222585, 
+    19.08113668772821];
+
+    test("synchronization", function () {
+        ok(TAN_VALUES.length == HALF_PERIOD, "tan has right sampling rate");
+    });
+
+    // What value should we get for sin(index*2pi/FULL_PERIOD)?
+    var sin_benchmark = function (index) {
+        index %= FULL_PERIOD;  // why is -1 % 120 == -1?
+        index = index < 0 ? index + FULL_PERIOD : index;
+        return SIN_VALUES[index];
+    };
+
+    // What value should we get for cos(index*2pi/FULL_PERIOD)?
+    var cos_benchmark = function (index) {
+        index = (index + QUARTER_PER) % FULL_PERIOD;
+        index = index < 0 ? index + FULL_PERIOD : index;
+        return SIN_VALUES[index];
+    }
+
+    // What value should we get for tan(index*pi/60)?
+    var tan_benchmark = function (index) {
+        index = (index + QUARTER_PER) % HALF_PERIOD;
+        index = index < 0 ? index + FULL_PERIOD / 2 : index;
+        return TAN_VALUES[index];
+    }
+
+    // Which hits this benchmark better?
+    var benchmark_test = function(testee, benchmark, lower, upper, tol) {
+        if (tol === undefined) tol = 1e-15;
+        for (var i = lower; i <= upper; i++) {
+            if (isFinite(benchmark(i))) {
+                var message = "At 2*" + i + "*pi/" + FULL_PERIOD + " we get " 
+                                + benchmark(i);
+                QUnit.close(testee(i/HALF_PERIOD*Math.PI), benchmark(i), tol, message);
+            }
+        }
+    }
+
+    var run_benchmark_tests = function () {
+        var LOWER_BD = -20 * FULL_PERIOD;  // start testing at -40*pi
+        var UPPER_BD = 20 * FULL_PERIOD;  // stop testing at  40*pi
+        var range = "[" + (2 * LOWER_BD/FULL_PERIOD) + "pi, " 
+                    + (2* UPPER_BD/FULL_PERIOD) + "pi]";
+
+        test("sanity check: Math.sin on " + range, function () { 
+            benchmark_test(Math.sin, sin_benchmark, LOWER_BD, UPPER_BD, 1e-13);
+        });
+        test("sanity check: Math.cos on " + range, function () {
+            benchmark_test(Math.cos, cos_benchmark, LOWER_BD, UPPER_BD, 1e-13);
+        });
+        test("sanity check: Math.tan on " + range, function () {
+            benchmark_test(Math.tan, tan_benchmark, LOWER_BD, UPPER_BD, 1e-11);
+        });
+
+        test("calibration: shifted.sin on " + range, function () { 
+            benchmark_test(shiftedSin, sin_benchmark, LOWER_BD, UPPER_BD, 1e-13);
+        });
+        test("calibration: shifted.cos on " + range, function () {
+            benchmark_test(shiftedCos, cos_benchmark, LOWER_BD, UPPER_BD, 1e-13);
+        });
+        test("calibration: shifted.tan on " + range, function () {
+            benchmark_test(shiftedTan, tan_benchmark, LOWER_BD, UPPER_BD, 1e-11);
+        });
+    };
+    run_benchmark_tests();
+    
+
+    // Some pedagogically relevant values of trig functions are every pi/2 radians.
+    var important_values = function(testee, lib, bench, lower, upper) {
+        for (var i = lower - (lower % QUARTER_PER); i <= upper; i += QUARTER_PER) {
+            if (isFinite(bench(i))) {
+                var testee_err = Math.abs(testee(i/HALF_PERIOD*Math.PI) - bench(i));
+                var lib_err = Math.abs(lib(i/HALF_PERIOD*Math.PI) - bench(i));
+                var message = "shifted error (" + testee_err + ") <= "
+                             + "library error (" + lib_err + ") at "
+                             + i/HALF_PERIOD + "pi"
+
+                ok(testee_err <= lib_err, message);
+            }
+        }
+    }
+
+    var run_important_values_tests = function () {
+        var LOWER_BD = -3 * FULL_PERIOD;
+        var UPPER_BD = 3 * FULL_PERIOD;
+        var range = "[" + LOWER_BD/HALF_PERIOD + "pi, " + UPPER_BD/HALF_PERIOD + "pi]";
+
+        test("important values: shifted.sin on " + range, function () { 
+            important_values(shiftedSin, Math.sin, sin_benchmark, LOWER_BD, UPPER_BD);
+        });
+        test("important values: shifted.cos on " + range, function () {
+            important_values(shiftedCos, Math.cos, cos_benchmark, LOWER_BD, UPPER_BD);
+        });
+        test("important values: shifted.tan on " + range, function () {
+            important_values(shiftedTan, Math.tan, tan_benchmark, LOWER_BD, UPPER_BD);
+        });
+    };
+    run_important_values_tests();
+
+})(KAS);
+</script>
+
+</html>

--- a/shifted_trig_test.html
+++ b/shifted_trig_test.html
@@ -38,6 +38,13 @@
     var shiftedSin = KAS.Trig.shifted.sin;
     var shiftedCos = KAS.Trig.shifted.cos;
     var shiftedTan = KAS.Trig.shifted.tan;
+    var shiftedCsc = KAS.Trig.shifted.csc;
+    var shiftedSec = KAS.Trig.shifted.sec;
+    var shiftedCot = KAS.Trig.shifted.cot;
+
+    var csc = function (arg) { return 1 / Math.sin(arg); };
+    var sec = function (arg) { return 1 / Math.cos(arg); };
+    var cot = function (arg) { return 1 / Math.tan(arg); };
 
     // Here's a list of benchmark values of sine every pi/60 radians in [0, 2pi]
     // These were calculated in sympy.
@@ -52,50 +59,57 @@
 
     // Here are some max precision benchmark values for tangent.
     var TAN_VALUES = 
-        [NaN, -19.08113668772821, -9.514364454222585, -6.313751514675043, 
-         -4.704630109478454, -3.732050807568877, -3.077683537175253,  
-         -2.605089064693802, -2.246036773904216, -1.962610505505151,
-         -1.732050807568877,  -1.539864963814583, -1.376381920471174, 
-         -1.234897156535051, -1.110612514829193,  -1.000000000000000, 
-         -0.9004040442978399, -0.8097840331950071,  -0.7265425280053609, 
-         -0.6494075931975106, -0.5773502691896258,  -0.5095254494944288, 
-         -0.4452286853085362, -0.3838640350354158,  -0.3249196962329063, 
-         -0.2679491924311227, -0.2125565616700221,  -0.1583844403245363, 
-         -0.1051042352656765, -0.05240777928304120,  0, 0.05240777928304120, 
-         0.1051042352656765, 0.1583844403245363,  0.2125565616700221, 
-         0.2679491924311227, 0.3249196962329063, 0.3838640350354158, 
-         0.4452286853085362, 0.5095254494944288,  0.5773502691896258,
-        0.6494075931975106, 0.7265425280053609,  0.8097840331950071, 
-        0.9004040442978399, 1.000000000000000,  1.110612514829193, 
-        1.234897156535051, 1.376381920471174, 1.539864963814583, 1.732050807568877, 
-        1.962610505505151,  2.246036773904216, 2.605089064693802, 3.077683537175253,
-        3.732050807568877, 4.704630109478454, 6.313751514675043,  9.514364454222585, 
-    19.08113668772821];
+        [NaN, -19.08113668772821, -9.514364454222585, -6.313751514675043, -4.704630109478454, -3.732050807568877, -3.077683537175253, -2.605089064693802, -2.246036773904216, -1.962610505505151, -1.732050807568877, -1.539864963814583, -1.376381920471174, -1.234897156535051, -1.110612514829193, -1.000000000000000, -0.9004040442978399, -0.8097840331950071, -0.7265425280053609, -0.6494075931975106, -0.5773502691896258, -0.5095254494944288, -0.4452286853085362, -0.3838640350354158, -0.3249196962329063, -0.2679491924311227, -0.2125565616700221, -0.1583844403245363, -0.1051042352656765, -0.05240777928304120, 0, 0.05240777928304120, 0.1051042352656765, 0.1583844403245363, 0.2125565616700221, 0.2679491924311227, 0.3249196962329063, 0.3838640350354158, 0.4452286853085362, 0.5095254494944288, 0.5773502691896258, 0.6494075931975106, 0.7265425280053609, 0.8097840331950071, 0.9004040442978399, 1.000000000000000, 1.110612514829193, 1.234897156535051, 1.376381920471174, 1.539864963814583, 1.732050807568877, 1.962610505505151, 2.246036773904216, 2.605089064693802, 3.077683537175253, 3.732050807568877, 4.704630109478454, 6.313751514675043, 9.514364454222585, 19.08113668772821];
+
+    var CSC_VALUES = 
+        [NaN, 19.107322609297398, 9.5667722335056263, 6.3924532214996612, 4.8097343447441308, 3.8637033051562734, 3.2360679774997895, 2.7904281096253359, 2.4585933355742382, 2.2026892645852667, 2.0000000000000001, 1.8360784587766633, 1.7013016167040798, 1.5890157290657494, 1.4944765498646086, 1.4142135623730950, 1.3456327296063761, 1.2867595658931674, 1.2360679774997897, 1.1923632928359475, 1.1547005383792516, 1.1223262376343608, 1.0946362785060468, 1.0711449936370290, 1.0514622242382672, 1.0352761804100830, 1.0223405948650293, 1.0124651257880029, 1.0055082795635164, 1.0013723459979210, 1.0000000000000000, 1.0013723459979210, 1.0055082795635164, 1.0124651257880030, 1.0223405948650293, 1.0352761804100831, 1.0514622242382672, 1.0711449936370291, 1.0946362785060467, 1.1223262376343608, 1.1547005383792515, 1.1923632928359475, 1.2360679774997896, 1.2867595658931674, 1.3456327296063759, 1.4142135623730950, 1.4944765498646089, 1.5890157290657494, 1.7013016167040802, 1.8360784587766630, 2.0000000000000004, 2.2026892645852663, 2.4585933355742387, 2.7904281096253352, 3.2360679774997904, 3.8637033051562715, 4.8097343447441318, 6.3924532214996559, 9.5667722335056282, 19.107322609297339, NaN, -19.107322609297466, -9.5667722335055965, -6.3924532214996559, -4.8097343447441318, -3.8637033051562765, -3.2360679774997869, -2.7904281096253352, -2.4585933355742387, -2.2026892645852678, -1.9999999999999992, -1.8360784587766630, -1.7013016167040802, -1.5890157290657501, -1.4944765498646084, -1.4142135623730950, -1.3456327296063763, -1.2867595658931670, -1.2360679774997896, -1.1923632928359475, -1.1547005383792517, -1.1223262376343606, -1.0946362785060467, -1.0711449936370291, -1.0514622242382673, -1.0352761804100830, -1.0223405948650293, -1.0124651257880030, -1.0055082795635164, -1.0013723459979210, -1.0000000000000000, -1.0013723459979210, -1.0055082795635164, -1.0124651257880030, -1.0223405948650293, -1.0352761804100830, -1.0514622242382673, -1.0711449936370291, -1.0946362785060467, -1.1223262376343606, -1.1547005383792517, -1.1923632928359475, -1.2360679774997896, -1.2867595658931670, -1.3456327296063763, -1.4142135623730950, -1.4944765498646084, -1.5890157290657501, -1.7013016167040802, -1.8360784587766630, -1.9999999999999992, -2.2026892645852678, -2.4585933355742387, -2.7904281096253352, -3.2360679774997869, -3.8637033051562765, -4.8097343447441318, -6.3924532214996559, -9.5667722335055965, -19.107322609297466];
 
     test("synchronization", function () {
         ok(TAN_VALUES.length == HALF_PERIOD, "tan has right sampling rate");
+        ok(CSC_VALUES.length == FULL_PERIOD, "csc has right sampling rate");
     });
 
     // What value should we get for sin(index*2pi/FULL_PERIOD)?
     var sin_benchmark = function (index) {
         index %= FULL_PERIOD;  // why is -1 % 120 == -1?
-        index = index < 0 ? index + FULL_PERIOD : index;
+        if (index < 0) index += FULL_PERIOD;
         return SIN_VALUES[index];
     };
 
     // What value should we get for cos(index*2pi/FULL_PERIOD)?
     var cos_benchmark = function (index) {
         index = (index + QUARTER_PER) % FULL_PERIOD;
-        index = index < 0 ? index + FULL_PERIOD : index;
+        if (index < 0) index += FULL_PERIOD;
         return SIN_VALUES[index];
-    }
+    };
 
     // What value should we get for tan(index*pi/60)?
     var tan_benchmark = function (index) {
         index = (index + QUARTER_PER) % HALF_PERIOD;
-        index = index < 0 ? index + FULL_PERIOD / 2 : index;
+        if (index < 0) index += HALF_PERIOD;
         return TAN_VALUES[index];
-    }
+    };
+
+    // What value should we get for csc(index*2pi/FULL_PERIOD)?
+    var csc_benchmark = function (index) {
+        index %= FULL_PERIOD;
+        if (index < 0) index += FULL_PERIOD;
+        return CSC_VALUES[index];
+    };
+
+    // What value should we get for sec(index*2pi/FULL_PERIOD)?
+    var sec_benchmark = function (index) {
+        index = (index + QUARTER_PER) % FULL_PERIOD;
+        if (index < 0) index += FULL_PERIOD;
+        return CSC_VALUES[index];
+    };
+
+    // What value should we get for cot(index*pi/60)?
+    var cot_benchmark = function (index) {
+        index = - index % HALF_PERIOD;
+        if (index < 0) index += HALF_PERIOD;
+        return TAN_VALUES[index];
+    };
 
     // Which hits this benchmark better?
     var benchmark_test = function(testee, benchmark, lower, upper, tol) {
@@ -124,6 +138,15 @@
         test("sanity check: Math.tan on " + range, function () {
             benchmark_test(Math.tan, tan_benchmark, LOWER_BD, UPPER_BD, 1e-11);
         });
+        test("sanity check: Math.csc on " + range, function () { 
+            benchmark_test(csc, csc_benchmark, LOWER_BD, UPPER_BD, 1e-11);
+        });
+        test("sanity check: Math.sec on " + range, function () {
+            benchmark_test(sec, sec_benchmark, LOWER_BD, UPPER_BD, 1e-11);
+        });
+        test("sanity check: Math.cot on " + range, function () {
+            benchmark_test(cot, cot_benchmark, LOWER_BD, UPPER_BD, 1e-11);
+        });
 
         test("calibration: shifted.sin on " + range, function () { 
             benchmark_test(shiftedSin, sin_benchmark, LOWER_BD, UPPER_BD, 1e-13);
@@ -133,6 +156,15 @@
         });
         test("calibration: shifted.tan on " + range, function () {
             benchmark_test(shiftedTan, tan_benchmark, LOWER_BD, UPPER_BD, 1e-11);
+        });
+        test("calibration: shifted.csc on " + range, function () { 
+            benchmark_test(shiftedCsc, csc_benchmark, LOWER_BD, UPPER_BD, 1e-11);
+        });
+        test("calibration: shifted.sec on " + range, function () {
+            benchmark_test(shiftedSec, sec_benchmark, LOWER_BD, UPPER_BD, 1e-11);
+        });
+        test("calibration: shifted.cot on " + range, function () {
+            benchmark_test(shiftedCot, cot_benchmark, LOWER_BD, UPPER_BD, 1e-11);
         });
     };
     run_benchmark_tests();
@@ -166,6 +198,15 @@
         });
         test("important values: shifted.tan on " + range, function () {
             important_values(shiftedTan, Math.tan, tan_benchmark, LOWER_BD, UPPER_BD);
+        });
+        test("important values: shifted.csc on " + range, function () { 
+            important_values(shiftedCsc, csc, csc_benchmark, LOWER_BD, UPPER_BD);
+        });
+        test("important values: shifted.sec on " + range, function () {
+            important_values(shiftedSec, sec, sec_benchmark, LOWER_BD, UPPER_BD);
+        });
+        test("important values: shifted.cot on " + range, function () {
+            important_values(shiftedCot, cot, cot_benchmark, LOWER_BD, UPPER_BD);
         });
     };
     run_important_values_tests();

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1907,26 +1907,51 @@ _.extend(Log, {
 function Trig(type, arg) { this.type = type; this.arg = arg; }
 Trig.prototype = new Expr();
 
+Trig.shifted = {
+    sin: function(arg) {
+        var region = Math.round(arg / Math.PI);  
+        if (region % 2 == 0) {
+            var shiftedArg = arg - region * Math.PI;
+        } else {
+            var shiftedArg = region * Math.PI - arg;
+        }
+        return Math.sin(shiftedArg);
+    },
+
+    cos: function (arg) {
+        var region = Math.round(arg / Math.PI + 1/2);
+        if (region % 2 == 0) {
+            var shiftedArg = region * Math.PI - arg - Math.PI/2;
+        } else {
+            var shiftedArg = arg + Math.PI/2 - region * Math.PI;
+        }
+        return -Math.sin(shiftedArg);
+    },
+
+    tan: function (arg) { return Trig.shifted.sin(arg) / Trig.shifted.cos(arg); },
+
+}
+
 _.extend(Trig.prototype, {
     func: Trig,
     args: function() { return [this.type, this.arg]; },
 
     functions: {
         sin: {
-            eval: Math.sin,
-            codegen: "Math.sin((",
+            eval: Trig.shifted.sin,
+            codegen: "KAS.Trig.shifted.sin((",
             tex: "\\sin",
             expand: function() { return this; }
         },
         cos: {
-            eval: Math.cos,
-            codegen: "Math.cos((",
+            eval: Trig.shifted.cos,
+            codegen: "KAS.Trig.shifted.cos((",
             tex: "\\cos",
             expand: function() { return this; }
         },
         tan: {
-            eval: Math.tan,
-            codegen: "Math.tan((",
+            eval: Trig.shifted.tan,
+            codegen: "KAS.Trig.shifted.tan((",
             tex: "\\tan",
             expand: function() {
                 return Mul.handleDivide(Trig.sin(this.arg), Trig.cos(this.arg));

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1928,9 +1928,19 @@ Trig.shifted = {
         return -Math.sin(shiftedArg);
     },
 
-    tan: function (arg) { return Trig.shifted.sin(arg) / Trig.shifted.cos(arg); },
-
-}
+    tan: function (arg) { 
+        return Trig.shifted.sin(arg) / Trig.shifted.cos(arg); 
+    },
+    csc: function (arg) {
+        return 1 / Trig.shifted.sin(arg);
+    },
+    sec: function (arg) {
+        return 1 / Trig.shifted.cos(arg);
+    },
+    cot: function (arg) {
+        return Trig.shifted.cos(arg) / Trig.shifted.sin(arg);
+    }
+};
 
 _.extend(Trig.prototype, {
     func: Trig,
@@ -1958,24 +1968,24 @@ _.extend(Trig.prototype, {
             }
         },
         csc: {
-            eval: function(arg) { return 1 / Math.sin(arg); },
-            codegen: "(1/Math.sin(",
+            eval: Trig.shifted.csc,
+            codegen: "KAS.Trig.shifted.csc((",
             tex: "\\csc",
             expand: function() {
                 return Mul.handleDivide(Num.One, Trig.sin(this.arg));
             }
         },
         sec: {
-            eval: function(arg) { return 1 / Math.cos(arg); },
-            codegen: "(1/Math.cos(",
+            eval: Trig.shifted.sec,
+            codegen: "KAS.Trig.shifted.sec((",
             tex: "\\sec",
             expand: function() {
                 return Mul.handleDivide(Num.One, Trig.cos(this.arg));
             }
         },
         cot: {
-            eval: function(arg) { return 1 / Math.tan(arg); },
-            codegen: "(1/Math.tan(",
+            eval: Trig.shifted.cot,
+            codegen: "KAS.Trig.shifted.cot((",
             tex: "\\cot",
             expand: function() {
                 return Mul.handleDivide(Trig.cos(this.arg), Trig.sin(this.arg));

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -730,7 +730,7 @@ _.extend(Mul.prototype, {
     codegen: function() {
         return _.map(this.terms, function(term) {
             return "(" + term.codegen() + ")";
-        }).join(" * ") || "0";
+        }).join(" * ") || "1";
     },
 
     print: function() {

--- a/test.html
+++ b/test.html
@@ -729,6 +729,12 @@
         strictEqual(parse(input, {functions: functions}).eval(vars, {functions: functions}), expected, message);
     };
 
+    var finite = function(input, expectedBool, vars, functions) {
+        if (vars === undefined) vars = {};
+        var message = input + " is " + (expectedBool ? "" : "NOT ") + "finite";
+        strictEqual(isFinite(parse(input, {functions: functions}).eval(vars, {functions: functions})), expectedBool, message);
+    }
+
     test("empty", function() {
         val("", 0);
     });
@@ -749,6 +755,25 @@
         val("ln e", 1);
         val("log 10", 1);
         val("log_2 2", 1);
+        finite("1/0", false);             
+    });
+
+    test("trigonometric expressions", function () {
+        val("sin(-pi)", 0);
+        val("cos(-pi)", -1);
+        val("tan(-pi)", 0);
+        val("sin(-pi/2)", -1);
+        val("cos(-pi/2)", 0);
+        finite("tan(-pi/2)", false);
+        val("sin(0)", 0);
+        val("cos(0)", 1);
+        val("tan(0)", 0);
+        val("sin(pi/2)", 1);
+        val("cos(pi/2)", 0);
+        finite("tan(pi/2)", false);
+        val("sin(pi)", 0);
+        val("cos(pi)", -1);
+        val("tan(pi)", 0);
     });
 
     test("hyperbolic expressions", function() {
@@ -786,7 +811,7 @@
             throw new Error("invalid function: " + func.toString());
         }
         var message = input + " should evaluate to " + expected +
-			", was " + result + "; by func: " + func.toString();
+            ", was " + result + "; by func: " + func.toString();
         ok(Math.abs(result - expected) < 1e-9, message);
     };
 


### PR DESCRIPTION
Math.sin appears to be more accurate near the origin than farther away. By shifting arguments into [-pi/2, pi/2] before applying the library function, we achieve more accurate results near the origin, especially at multiples of pi/2. In particular, now sin(pi) is exactly 0.

Compounding shifting error with the library function error means this strategy is less accurate as the shift gets large. However, the error is still comparable to that of the library function, within 1e-11 on [-40pi, 40pi].

Closes #9.