### PR TITLE
Set the default value of isRadical in Pow to false

### DIFF
--- a/kas.js
+++ b/kas.js
@@ -924,7 +924,7 @@ KAS.parser = parser;
   }
 */
 var parser = (function(){
-var o=function(k,v,o,l){for(o=o||{},l=k.length;l--;o[k[l]]=v);return o},$V0=[1,11],$V1=[1,9],$V2=[8,17],$V3=[6,11],$V4=[6,11,13,17];
+var o=function(k,v,o,l){for(o=o||{},l=k.length;l--;o[k[l]]=v);return o;},$V0=[1,11],$V1=[1,9],$V2=[8,17],$V3=[6,11],$V4=[6,11,13,17];
 var parser = {trace: function trace() { },
 yy: {},
 symbols_: {"error":2,"unitvalue":3,"magnitude":4,"unit":5,"EOF":6,"float":7,"POW":8,"int":9,"multatoms":10,"DIV":11,"expatom":12,"MUL":13,"atom":14,"^":15,"nat":16,"ATOM":17,"FLOAT":18,"NAT":19,"NEG":20,"$accept":0,"$end":1},
@@ -949,7 +949,7 @@ case 2:
             return {
                 type: "unitStandalone",
                 unit: $$[$0-1],
-            }
+            };
         
 break;
 case 3:
@@ -1010,12 +1010,12 @@ break;
 }
 },
 table: [{3:1,4:2,5:3,7:4,10:5,12:8,14:10,16:7,17:$V0,18:[1,6],19:$V1},{1:[3]},{5:12,10:5,12:8,14:10,17:$V0},{6:[1,13]},{8:[1,14],17:[2,4]},{6:[2,6],11:[1,15]},o($V2,[2,13]),o($V2,[2,14]),o($V3,[2,9],{12:8,14:10,10:17,13:[1,16],17:$V0}),o([6,8,11,13,17],[2,15]),o($V4,[2,11],{15:[1,18]}),o([6,11,13,15,17],[2,12]),{6:[1,19]},{1:[2,2]},{9:20,19:[1,22],20:[1,21]},{10:23,12:8,14:10,17:$V0},{10:24,12:8,14:10,17:$V0},o($V3,[2,8]),{16:25,19:$V1},{1:[2,1]},{17:[2,3]},{19:[1,26]},{17:[2,17]},{6:[2,5]},o($V3,[2,7]),o($V4,[2,10]),{17:[2,16]}],
-defaultActions: {13:[2,2],19:[2,1],20:[2,3],22:[2,17],23:[2,5],26:[2,16]},
+defaultActions: {13:[2, 2], 19:[2, 1], 20:[2, 3], 22:[2, 17], 23:[2, 5], 26:[2, 16]},
 parseError: function parseError(str, hash) {
     if (hash.recoverable) {
         this.trace(str);
     } else {
-        function _parseError (msg, hash) {
+        function _parseError(msg, hash) {
             this.message = msg;
             this.hash = hash;
         }
@@ -1028,7 +1028,7 @@ parse: function parse(input) {
     var self = this, stack = [0], tstack = [], vstack = [null], lstack = [], table = this.table, yytext = '', yylineno = 0, yyleng = 0, recovering = 0, TERROR = 2, EOF = 1;
     var args = lstack.slice.call(arguments, 1);
     var lexer = Object.create(this.lexer);
-    var sharedState = { yy: {} };
+    var sharedState = {yy: {}};
     for (var k in this.yy) {
         if (Object.prototype.hasOwnProperty.call(this.yy, k)) {
             sharedState.yy[k] = this.yy[k];
@@ -1054,7 +1054,7 @@ parse: function parse(input) {
         lstack.length = lstack.length - n;
     }
     _token_stack:
-        var lex = function () {
+        var lex = function() {
             var token;
             token = lexer.lex() || EOF;
             if (typeof token !== 'number') {
@@ -1091,7 +1091,7 @@ parse: function parse(input) {
                     token: this.terminals_[symbol] || symbol,
                     line: lexer.yylineno,
                     loc: yyloc,
-                    expected: expected
+                    expected: expected,
                 });
             }
         if (action[0] instanceof Array && action.length > 1) {
@@ -1124,12 +1124,12 @@ parse: function parse(input) {
                 first_line: lstack[lstack.length - (len || 1)].first_line,
                 last_line: lstack[lstack.length - 1].last_line,
                 first_column: lstack[lstack.length - (len || 1)].first_column,
-                last_column: lstack[lstack.length - 1].last_column
+                last_column: lstack[lstack.length - 1].last_column,
             };
             if (ranges) {
                 yyval._$.range = [
                     lstack[lstack.length - (len || 1)].range[0],
-                    lstack[lstack.length - 1].range[1]
+                    lstack[lstack.length - 1].range[1],
                 ];
             }
             r = this.performAction.apply(yyval, [
@@ -1139,7 +1139,7 @@ parse: function parse(input) {
                 sharedState.yy,
                 action[1],
                 vstack,
-                lstack
+                lstack,
             ].concat(args));
             if (typeof r !== 'undefined') {
                 return r;
@@ -1176,7 +1176,7 @@ parseError:function parseError(str, hash) {
     },
 
 // resets the lexer, sets new input
-setInput:function (input, yy) {
+setInput:function(input, yy) {
         this.yy = yy || this.yy || {};
         this._input = input;
         this._more = this._backtrack = this.done = false;
@@ -1187,17 +1187,17 @@ setInput:function (input, yy) {
             first_line: 1,
             first_column: 0,
             last_line: 1,
-            last_column: 0
+            last_column: 0,
         };
         if (this.options.ranges) {
-            this.yylloc.range = [0,0];
+            this.yylloc.range = [0, 0];
         }
         this.offset = 0;
         return this;
     },
 
 // consumes and returns one char from the input
-input:function () {
+input:function() {
         var ch = this._input[0];
         this.yytext += ch;
         this.yyleng++;
@@ -1220,7 +1220,7 @@ input:function () {
     },
 
 // unshifts one char (or a string) into the input
-unput:function (ch) {
+unput:function(ch) {
         var len = ch.length;
         var lines = ch.split(/(?:\r\n?|\n)/g);
 
@@ -1244,7 +1244,7 @@ unput:function (ch) {
             last_column: lines ?
                 (lines.length === oldLines.length ? this.yylloc.first_column : 0)
                  + oldLines[oldLines.length - lines.length].length - lines[0].length :
-              this.yylloc.first_column - len
+              this.yylloc.first_column - len,
         };
 
         if (this.options.ranges) {
@@ -1255,20 +1255,20 @@ unput:function (ch) {
     },
 
 // When called from action, caches matched text and appends it on next action
-more:function () {
+more:function() {
         this._more = true;
         return this;
     },
 
 // When called from action, signals the lexer that this rule fails to match the input, so the next matching rule (regex) should be tested instead.
-reject:function () {
+reject:function() {
         if (this.options.backtrack_lexer) {
             this._backtrack = true;
         } else {
             return this.parseError('Lexical error on line ' + (this.yylineno + 1) + '. You can only invoke reject() in the lexer when the lexer is of the backtracking persuasion (options.backtrack_lexer = true).\n' + this.showPosition(), {
                 text: "",
                 token: null,
-                line: this.yylineno
+                line: this.yylineno,
             });
 
         }
@@ -1276,18 +1276,18 @@ reject:function () {
     },
 
 // retain first n characters of the match
-less:function (n) {
+less:function(n) {
         this.unput(this.match.slice(n));
     },
 
 // displays already matched input, i.e. for error messages
-pastInput:function () {
+pastInput:function() {
         var past = this.matched.substr(0, this.matched.length - this.match.length);
         return (past.length > 20 ? '...':'') + past.substr(-20).replace(/\n/g, "");
     },
 
 // displays upcoming input, i.e. for error messages
-upcomingInput:function () {
+upcomingInput:function() {
         var next = this.match;
         if (next.length < 20) {
             next += this._input.substr(0, 20-next.length);
@@ -1296,14 +1296,14 @@ upcomingInput:function () {
     },
 
 // displays the character position where the lexing error occurred, i.e. for error messages
-showPosition:function () {
+showPosition:function() {
         var pre = this.pastInput();
         var c = new Array(pre.length + 1).join("-");
         return pre + this.upcomingInput() + "\n" + c + "^";
     },
 
 // test the lexed token: return FALSE when not a match, otherwise return token
-test_match:function (match, indexed_rule) {
+test_match:function(match, indexed_rule) {
         var token,
             lines,
             backup;
@@ -1316,7 +1316,7 @@ test_match:function (match, indexed_rule) {
                     first_line: this.yylloc.first_line,
                     last_line: this.last_line,
                     first_column: this.yylloc.first_column,
-                    last_column: this.yylloc.last_column
+                    last_column: this.yylloc.last_column,
                 },
                 yytext: this.yytext,
                 match: this.match,
@@ -1328,7 +1328,7 @@ test_match:function (match, indexed_rule) {
                 _input: this._input,
                 yy: this.yy,
                 conditionStack: this.conditionStack.slice(0),
-                done: this.done
+                done: this.done,
             };
             if (this.options.ranges) {
                 backup.yylloc.range = this.yylloc.range.slice(0);
@@ -1345,7 +1345,7 @@ test_match:function (match, indexed_rule) {
             first_column: this.yylloc.last_column,
             last_column: lines ?
                          lines[lines.length - 1].length - lines[lines.length - 1].match(/\r?\n?/)[0].length :
-                         this.yylloc.last_column + match[0].length
+                         this.yylloc.last_column + match[0].length,
         };
         this.yytext += match[0];
         this.match += match[0];
@@ -1375,7 +1375,7 @@ test_match:function (match, indexed_rule) {
     },
 
 // return next match in input
-next:function () {
+next:function() {
         if (this.done) {
             return this.EOF;
         }
@@ -1427,7 +1427,7 @@ next:function () {
             return this.parseError('Lexical error on line ' + (this.yylineno + 1) + '. Unrecognized text.\n' + this.showPosition(), {
                 text: "",
                 token: null,
-                line: this.yylineno
+                line: this.yylineno,
             });
         }
     },
@@ -1486,7 +1486,7 @@ stateStackSize:function stateStackSize() {
         return this.conditionStack.length;
     },
 options: {},
-performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {
+performAction: function anonymous(yy, yy_, $avoiding_name_collisions, YY_START) {
 var YYSTATE=YY_START;
 switch($avoiding_name_collisions) {
 case 0:return 11;
@@ -1520,12 +1520,12 @@ break;
 }
 },
 rules: [/^(?:\/)/,/^(?:\()/,/^(?:\))/,/^(?:(\*|x|\u00d7|\u2219|\u22c5|\u00b7)\s*10\s*\^)/,/^(?:\^)/,/^(?:\*)/,/^(?:[0-9]+\.[0-9]+)/,/^(?:[0-9]+)/,/^(?:-)/,/^(?:\u00b0( ?)[cCfF])/,/^(?:fl\.? oz\.?)/,/^(?:[\u00b5]?([A-Za-z-]+|[\u2103\u2109\u212b]))/,/^(?:\s+)/,/^(?:$)/],
-conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13],"inclusive":true}}
+conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13],"inclusive":true}},
 });
 return lexer;
 })();
 parser.lexer = lexer;
-function Parser () {
+function Parser() {
   this.yy = {};
 }
 Parser.prototype = parser;parser.Parser = Parser;
@@ -1617,7 +1617,9 @@ _.extend(Expr.prototype, {
     recurse: function(method) {
         var passed = Array.prototype.slice.call(arguments, 1);
         var args = _.map(this.args(), function(arg) {
-            return _.isString(arg) || typeof(arg) == "boolean" ? arg : arg[method].apply(arg, passed);
+            return (_.isString(arg) || typeof arg == "boolean")
+                ? arg
+                : arg[method].apply(arg, passed);
         });
         return this.construct(args);
     },
@@ -2920,7 +2922,11 @@ _.extend(Mul, {
 
 
 /* exponentiation */
-function Pow(base, exp, isRadical) { this.base = base; this.exp = exp; this.isRadical = isRadical;}
+function Pow(base, exp, isRadical = false) {
+    this.base = base;
+    this.exp = exp;
+    this.isRadical = isRadical;
+}
 Pow.prototype = new Expr();
 
 _.extend(Pow.prototype, {
@@ -3061,7 +3067,7 @@ _.extend(Pow.prototype, {
             };
 
             // compute and cache powers of 2 up to n
-            var cache = { 1: pow.base };
+            var cache = {1: pow.base};
             for (var i = 2; i <= n; i *= 2) {
                 var mul = new Mul(cache[i / 2], cache[i / 2]);
                 cache[i] = mul.expand().collect();
@@ -4654,9 +4660,9 @@ KAS.parse = function(input, options) {
         }
 
         var expr = parser.parse(input).completeParse();
-        return { parsed: true, expr: expr };
+        return {parsed: true, expr: expr};
     } catch (e) {
-        return { parsed: false, error: e.message };
+        return {parsed: false, error: e.message};
     }
 };
 
@@ -4760,7 +4766,7 @@ KAS.unitParse = function(input) {
             };
         }
     } catch (e) {
-        return { parsed: false, error: e.message };
+        return {parsed: false, error: e.message};
     }
 };
 
@@ -4780,7 +4786,7 @@ _.extend(Unit.prototype, {
         return 1;
     },
 
-    getUnits: function() { return [{ unit: this.symbol, pow: 1 }]; },
+    getUnits: function() { return [{unit: this.symbol, pow: 1}]; },
 
     codegen: function() { return "1"; },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,452 @@
+{
+  "name": "kas",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
+      "optional": true
+    },
+    "argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "dev": true,
+      "dependencies": {
+        "underscore": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+          "dev": true
+        }
+      }
+    },
+    "argsparser": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/argsparser/-/argsparser-0.0.6.tgz",
+      "integrity": "sha1-/0XrW5LABCJc8UalHTOdzLJlvmM=",
+      "dev": true
+    },
+    "async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+      "dev": true
+    },
+    "bunker": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+      "integrity": "sha1-yImSRkqOKm7ehpMDdfkrWAd++Xw=",
+      "dev": true,
+      "optional": true
+    },
+    "burrito": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+      "integrity": "sha1-0NbmrIHV6ZeJxvpKzLCwAx6lT2s=",
+      "dev": true,
+      "optional": true
+    },
+    "cjson": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+      "integrity": "sha1-5kObkHA9MS/24iJAl76pLOPQKhQ=",
+      "dev": true
+    },
+    "cli-table": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.0.2.tgz",
+      "integrity": "sha1-mChn4WQ1Mlxmwgih5xuVM26jCTs=",
+      "dev": true,
+      "dependencies": {
+        "colors": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.3.0.tgz",
+          "integrity": "sha1-wkfWTTTbDKTcjkPz7NbamNCvlOc=",
+          "dev": true
+        }
+      }
+    },
+    "coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+      "dev": true
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+      "dev": true
+    },
+    "ebnf-parser": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz",
+      "integrity": "sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+      "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
+      "dev": true,
+      "dependencies": {
+        "esprima": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
+          "integrity": "sha1-W28VR/TRAuZw4UDFCb5ncdautUk=",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
+      "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+      "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA=",
+      "dev": true
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true
+        }
+      }
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "dev": true,
+      "dependencies": {
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+      "dev": true
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dev": true
+    },
+    "grunt-contrib-concat": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.1.3.tgz",
+      "integrity": "sha1-35oam8jXX80AeUs9D22K6CeFI6w=",
+      "dev": true
+    },
+    "grunt-execute": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/grunt-execute/-/grunt-execute-0.1.5.tgz",
+      "integrity": "sha1-yX64lDYS/vu3L749Mu+VIzxfouk=",
+      "dev": true
+    },
+    "grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "dev": true,
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "dev": true,
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "dev": true
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "jison": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/jison/-/jison-0.4.17.tgz",
+      "integrity": "sha1-vBLUbFhF5v7onM81vSqMxz66F/M=",
+      "dev": true,
+      "dependencies": {
+        "esprima": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
+          "integrity": "sha1-W28VR/TRAuZw4UDFCb5ncdautUk=",
+          "dev": true
+        }
+      }
+    },
+    "jison-lex": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/jison-lex/-/jison-lex-0.3.4.tgz",
+      "integrity": "sha1-gcoo2E+ESZ36jFlNzePYo/Jux6U=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "dev": true
+    },
+    "jsonlint": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+      "integrity": "sha1-iKpGvCiaesk7tGyuLVihh6m7SUo=",
+      "dev": true
+    },
+    "JSONSelect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
+      "integrity": "sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40=",
+      "dev": true
+    },
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
+      "dev": true
+    },
+    "lex-parser": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/lex-parser/-/lex-parser-0.1.4.tgz",
+      "integrity": "sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true
+    },
+    "nomnom": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+      "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
+      "dev": true,
+      "dependencies": {
+        "colors": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+          "dev": true
+        },
+        "underscore": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+          "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA=",
+          "dev": true
+        }
+      }
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true
+    },
+    "qunit": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-0.5.18.tgz",
+      "integrity": "sha1-mIUJybn3raOqoXsR6JcQtvBK/rM=",
+      "dev": true,
+      "dependencies": {
+        "underscore": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz",
+          "integrity": "sha1-R6xTaD2vgyv6lS4XdEF9pHgXrkI=",
+          "dev": true
+        }
+      }
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+      "dev": true,
+      "optional": true
+    },
+    "tracejs": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/tracejs/-/tracejs-0.1.4.tgz",
+      "integrity": "sha1-KdvrSuEHiS92VIzfob6OGnN1jeY=",
+      "dev": true
+    },
+    "traverse": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
+      "integrity": "sha1-4gPFjV9/DjfbbnTArLkpuwm2HYU=",
+      "dev": true,
+      "optional": true
+    },
+    "uglify-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
+      "integrity": "sha1-7nGpfEzv0GoamyBDfzQRiYKqA1s=",
+      "dev": true,
+      "optional": true
+    },
+    "underscore": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
+      "integrity": "sha1-EzXF5PXm0zu7SwBrqMhqAPVW3gg="
+    },
+    "underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "dev": true
+    }
+  }
+}

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1386,7 +1386,7 @@ _.extend(Mul, {
 
 
 /* exponentiation */
-function Pow(base, exp, isRadical) {
+function Pow(base, exp, isRadical = false) {
     this.base = base;
     this.exp = exp;
     this.isRadical = isRadical;

--- a/src/unitparser.js
+++ b/src/unitparser.js
@@ -75,7 +75,7 @@
   }
 */
 var parser = (function(){
-var o=function(k,v,o,l){for(o=o||{},l=k.length;l--;o[k[l]]=v);return o;},$V0=[1,11],$V1=[1,9],$V2=[8,17],$V3=[6,11],$V4=[6,11,13,17];
+var o=function(k,v,o,l){for(o=o||{},l=k.length;l--;o[k[l]]=v);return o},$V0=[1,11],$V1=[1,9],$V2=[8,17],$V3=[6,11],$V4=[6,11,13,17];
 var parser = {trace: function trace() { },
 yy: {},
 symbols_: {"error":2,"unitvalue":3,"magnitude":4,"unit":5,"EOF":6,"float":7,"POW":8,"int":9,"multatoms":10,"DIV":11,"expatom":12,"MUL":13,"atom":14,"^":15,"nat":16,"ATOM":17,"FLOAT":18,"NAT":19,"NEG":20,"$accept":0,"$end":1},
@@ -100,7 +100,7 @@ case 2:
             return {
                 type: "unitStandalone",
                 unit: $$[$0-1],
-            };
+            }
         
 break;
 case 3:
@@ -161,12 +161,12 @@ break;
 }
 },
 table: [{3:1,4:2,5:3,7:4,10:5,12:8,14:10,16:7,17:$V0,18:[1,6],19:$V1},{1:[3]},{5:12,10:5,12:8,14:10,17:$V0},{6:[1,13]},{8:[1,14],17:[2,4]},{6:[2,6],11:[1,15]},o($V2,[2,13]),o($V2,[2,14]),o($V3,[2,9],{12:8,14:10,10:17,13:[1,16],17:$V0}),o([6,8,11,13,17],[2,15]),o($V4,[2,11],{15:[1,18]}),o([6,11,13,15,17],[2,12]),{6:[1,19]},{1:[2,2]},{9:20,19:[1,22],20:[1,21]},{10:23,12:8,14:10,17:$V0},{10:24,12:8,14:10,17:$V0},o($V3,[2,8]),{16:25,19:$V1},{1:[2,1]},{17:[2,3]},{19:[1,26]},{17:[2,17]},{6:[2,5]},o($V3,[2,7]),o($V4,[2,10]),{17:[2,16]}],
-defaultActions: {13:[2, 2], 19:[2, 1], 20:[2, 3], 22:[2, 17], 23:[2, 5], 26:[2, 16]},
+defaultActions: {13:[2,2],19:[2,1],20:[2,3],22:[2,17],23:[2,5],26:[2,16]},
 parseError: function parseError(str, hash) {
     if (hash.recoverable) {
         this.trace(str);
     } else {
-        function _parseError(msg, hash) {
+        function _parseError (msg, hash) {
             this.message = msg;
             this.hash = hash;
         }
@@ -179,7 +179,7 @@ parse: function parse(input) {
     var self = this, stack = [0], tstack = [], vstack = [null], lstack = [], table = this.table, yytext = '', yylineno = 0, yyleng = 0, recovering = 0, TERROR = 2, EOF = 1;
     var args = lstack.slice.call(arguments, 1);
     var lexer = Object.create(this.lexer);
-    var sharedState = {yy: {}};
+    var sharedState = { yy: {} };
     for (var k in this.yy) {
         if (Object.prototype.hasOwnProperty.call(this.yy, k)) {
             sharedState.yy[k] = this.yy[k];
@@ -205,7 +205,7 @@ parse: function parse(input) {
         lstack.length = lstack.length - n;
     }
     _token_stack:
-        var lex = function() {
+        var lex = function () {
             var token;
             token = lexer.lex() || EOF;
             if (typeof token !== 'number') {
@@ -242,7 +242,7 @@ parse: function parse(input) {
                     token: this.terminals_[symbol] || symbol,
                     line: lexer.yylineno,
                     loc: yyloc,
-                    expected: expected,
+                    expected: expected
                 });
             }
         if (action[0] instanceof Array && action.length > 1) {
@@ -275,12 +275,12 @@ parse: function parse(input) {
                 first_line: lstack[lstack.length - (len || 1)].first_line,
                 last_line: lstack[lstack.length - 1].last_line,
                 first_column: lstack[lstack.length - (len || 1)].first_column,
-                last_column: lstack[lstack.length - 1].last_column,
+                last_column: lstack[lstack.length - 1].last_column
             };
             if (ranges) {
                 yyval._$.range = [
                     lstack[lstack.length - (len || 1)].range[0],
-                    lstack[lstack.length - 1].range[1],
+                    lstack[lstack.length - 1].range[1]
                 ];
             }
             r = this.performAction.apply(yyval, [
@@ -290,7 +290,7 @@ parse: function parse(input) {
                 sharedState.yy,
                 action[1],
                 vstack,
-                lstack,
+                lstack
             ].concat(args));
             if (typeof r !== 'undefined') {
                 return r;
@@ -327,7 +327,7 @@ parseError:function parseError(str, hash) {
     },
 
 // resets the lexer, sets new input
-setInput:function(input, yy) {
+setInput:function (input, yy) {
         this.yy = yy || this.yy || {};
         this._input = input;
         this._more = this._backtrack = this.done = false;
@@ -338,17 +338,17 @@ setInput:function(input, yy) {
             first_line: 1,
             first_column: 0,
             last_line: 1,
-            last_column: 0,
+            last_column: 0
         };
         if (this.options.ranges) {
-            this.yylloc.range = [0, 0];
+            this.yylloc.range = [0,0];
         }
         this.offset = 0;
         return this;
     },
 
 // consumes and returns one char from the input
-input:function() {
+input:function () {
         var ch = this._input[0];
         this.yytext += ch;
         this.yyleng++;
@@ -371,7 +371,7 @@ input:function() {
     },
 
 // unshifts one char (or a string) into the input
-unput:function(ch) {
+unput:function (ch) {
         var len = ch.length;
         var lines = ch.split(/(?:\r\n?|\n)/g);
 
@@ -395,7 +395,7 @@ unput:function(ch) {
             last_column: lines ?
                 (lines.length === oldLines.length ? this.yylloc.first_column : 0)
                  + oldLines[oldLines.length - lines.length].length - lines[0].length :
-              this.yylloc.first_column - len,
+              this.yylloc.first_column - len
         };
 
         if (this.options.ranges) {
@@ -406,20 +406,20 @@ unput:function(ch) {
     },
 
 // When called from action, caches matched text and appends it on next action
-more:function() {
+more:function () {
         this._more = true;
         return this;
     },
 
 // When called from action, signals the lexer that this rule fails to match the input, so the next matching rule (regex) should be tested instead.
-reject:function() {
+reject:function () {
         if (this.options.backtrack_lexer) {
             this._backtrack = true;
         } else {
             return this.parseError('Lexical error on line ' + (this.yylineno + 1) + '. You can only invoke reject() in the lexer when the lexer is of the backtracking persuasion (options.backtrack_lexer = true).\n' + this.showPosition(), {
                 text: "",
                 token: null,
-                line: this.yylineno,
+                line: this.yylineno
             });
 
         }
@@ -427,18 +427,18 @@ reject:function() {
     },
 
 // retain first n characters of the match
-less:function(n) {
+less:function (n) {
         this.unput(this.match.slice(n));
     },
 
 // displays already matched input, i.e. for error messages
-pastInput:function() {
+pastInput:function () {
         var past = this.matched.substr(0, this.matched.length - this.match.length);
         return (past.length > 20 ? '...':'') + past.substr(-20).replace(/\n/g, "");
     },
 
 // displays upcoming input, i.e. for error messages
-upcomingInput:function() {
+upcomingInput:function () {
         var next = this.match;
         if (next.length < 20) {
             next += this._input.substr(0, 20-next.length);
@@ -447,14 +447,14 @@ upcomingInput:function() {
     },
 
 // displays the character position where the lexing error occurred, i.e. for error messages
-showPosition:function() {
+showPosition:function () {
         var pre = this.pastInput();
         var c = new Array(pre.length + 1).join("-");
         return pre + this.upcomingInput() + "\n" + c + "^";
     },
 
 // test the lexed token: return FALSE when not a match, otherwise return token
-test_match:function(match, indexed_rule) {
+test_match:function (match, indexed_rule) {
         var token,
             lines,
             backup;
@@ -467,7 +467,7 @@ test_match:function(match, indexed_rule) {
                     first_line: this.yylloc.first_line,
                     last_line: this.last_line,
                     first_column: this.yylloc.first_column,
-                    last_column: this.yylloc.last_column,
+                    last_column: this.yylloc.last_column
                 },
                 yytext: this.yytext,
                 match: this.match,
@@ -479,7 +479,7 @@ test_match:function(match, indexed_rule) {
                 _input: this._input,
                 yy: this.yy,
                 conditionStack: this.conditionStack.slice(0),
-                done: this.done,
+                done: this.done
             };
             if (this.options.ranges) {
                 backup.yylloc.range = this.yylloc.range.slice(0);
@@ -496,7 +496,7 @@ test_match:function(match, indexed_rule) {
             first_column: this.yylloc.last_column,
             last_column: lines ?
                          lines[lines.length - 1].length - lines[lines.length - 1].match(/\r?\n?/)[0].length :
-                         this.yylloc.last_column + match[0].length,
+                         this.yylloc.last_column + match[0].length
         };
         this.yytext += match[0];
         this.match += match[0];
@@ -526,7 +526,7 @@ test_match:function(match, indexed_rule) {
     },
 
 // return next match in input
-next:function() {
+next:function () {
         if (this.done) {
             return this.EOF;
         }
@@ -578,7 +578,7 @@ next:function() {
             return this.parseError('Lexical error on line ' + (this.yylineno + 1) + '. Unrecognized text.\n' + this.showPosition(), {
                 text: "",
                 token: null,
-                line: this.yylineno,
+                line: this.yylineno
             });
         }
     },
@@ -637,7 +637,7 @@ stateStackSize:function stateStackSize() {
         return this.conditionStack.length;
     },
 options: {},
-performAction: function anonymous(yy, yy_, $avoiding_name_collisions, YY_START) {
+performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {
 var YYSTATE=YY_START;
 switch($avoiding_name_collisions) {
 case 0:return 11;
@@ -671,12 +671,12 @@ break;
 }
 },
 rules: [/^(?:\/)/,/^(?:\()/,/^(?:\))/,/^(?:(\*|x|\u00d7|\u2219|\u22c5|\u00b7)\s*10\s*\^)/,/^(?:\^)/,/^(?:\*)/,/^(?:[0-9]+\.[0-9]+)/,/^(?:[0-9]+)/,/^(?:-)/,/^(?:\u00b0( ?)[cCfF])/,/^(?:fl\.? oz\.?)/,/^(?:[\u00b5]?([A-Za-z-]+|[\u2103\u2109\u212b]))/,/^(?:\s+)/,/^(?:$)/],
-conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13],"inclusive":true}},
+conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13],"inclusive":true}}
 });
 return lexer;
 })();
 parser.lexer = lexer;
-function Parser() {
+function Parser () {
   this.yy = {};
 }
 Parser.prototype = parser;parser.Parser = Parser;


### PR DESCRIPTION
Set the default value of isRadical in Pow to false, otherwise some
old-formatted code with only two parameters to Pow could not be run, such as this one in the README:
var expr1 = KAS.parse("(1-x)(-1-6x)").expr;
var expr2 = KAS.parse("(6x+1)(x-1)").expr;
KAS.compare(expr1, expr2).equal;
// true
