### PR TITLE
Update to grunt 1 and qunit 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kas",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -29,61 +29,256 @@
       "dev": true,
       "optional": true
     },
-    "argparse": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "underscore": "1.7.0",
-        "underscore.string": "2.4.0"
+        "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
       },
       "dependencies": {
-        "underscore": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
           "dev": true
         }
       }
     },
-    "argsparser": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/argsparser/-/argsparser-0.0.6.tgz",
-      "integrity": "sha1-/0XrW5LABCJc8UalHTOdzLJlvmM=",
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
     "async": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+      "version": "1.5.2",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
-    "bunker": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
-      "integrity": "sha1-yImSRkqOKm7ehpMDdfkrWAd++Xw=",
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "burrito": "0.2.12"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
       }
     },
-    "burrito": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
-      "integrity": "sha1-0NbmrIHV6ZeJxvpKzLCwAx6lT2s=",
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "traverse": "0.5.2",
-        "uglify-js": "1.1.1"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "bser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      }
+    },
+    "capture-exit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+      "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+      "dev": true,
+      "requires": {
+        "rsvp": "^3.3.3"
+      }
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "cjson": {
@@ -95,39 +290,188 @@
         "jsonlint": "1.6.0"
       }
     },
-    "cli-table": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.0.2.tgz",
-      "integrity": "sha1-mChn4WQ1Mlxmwgih5xuVM26jCTs=",
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "colors": "0.3.0"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
-        "colors": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.3.0.tgz",
-          "integrity": "sha1-wkfWTTTbDKTcjkPz7NbamNCvlOc=",
-          "dev": true
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
         }
       }
     },
-    "coffee-script": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+    "coffeescript": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
+      "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "version": "1.1.2",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
+    "commander": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
     "dateformat": {
-      "version": "1.0.2-1.2.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
-      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "ebnf-parser": {
@@ -136,16 +480,46 @@
       "integrity": "sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE=",
       "dev": true
     },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "ensure-posix-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
+      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI=",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
     "escodegen": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
       "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
       "dev": true,
       "requires": {
-        "esprima": "1.1.1",
-        "estraverse": "1.5.1",
-        "esutils": "1.0.0",
-        "source-map": "0.1.43"
+        "esprima": "~1.1.1",
+        "estraverse": "~1.5.0",
+        "esutils": "~1.0.0",
+        "source-map": "~0.1.33"
       },
       "dependencies": {
         "esprima": {
@@ -157,9 +531,9 @@
       }
     },
     "esprima": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
     "estraverse": {
@@ -180,49 +554,276 @@
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
+    "exec-sh": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+      "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+      "dev": true
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "exists-stat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/exists-stat/-/exists-stat-1.0.0.tgz",
+      "integrity": "sha1-BmDjUlouidnkRhKUQMJy7foktSk=",
+      "dev": true
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
-    "findup-sync": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "glob": "3.2.11",
-        "lodash": "2.4.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "is-descriptor": "^0.1.0"
           }
         },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "fb-watchman": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "dev": true,
+      "requires": {
+        "bser": "^2.0.0"
+      }
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "findup-sync": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+      "dev": true,
+      "requires": {
+        "glob": "~5.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
     },
     "getobject": {
       "version": "0.1.0",
@@ -231,56 +832,86 @@
       "dev": true
     },
     "glob": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+      "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
       "dev": true,
       "requires": {
-        "graceful-fs": "1.2.3",
-        "inherits": "1.0.2",
-        "minimatch": "0.2.14"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-          "dev": true
-        }
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "graceful-fs": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "grunt": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
-      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
+      "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "coffee-script": "1.3.3",
-        "colors": "0.6.2",
-        "dateformat": "1.0.2-1.2.3",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.1.3",
-        "getobject": "0.1.0",
-        "glob": "3.1.21",
-        "grunt-legacy-log": "0.1.3",
-        "grunt-legacy-util": "0.2.0",
-        "hooker": "0.2.3",
-        "iconv-lite": "0.2.11",
-        "js-yaml": "2.0.5",
-        "lodash": "0.9.2",
-        "minimatch": "0.2.14",
-        "nopt": "1.0.10",
-        "rimraf": "2.2.8",
-        "underscore.string": "2.2.1",
-        "which": "1.0.9"
+        "coffeescript": "~1.10.0",
+        "dateformat": "~1.0.12",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.0.0",
+        "grunt-cli": "~1.2.0",
+        "grunt-known-options": "~1.1.0",
+        "grunt-legacy-log": "~2.0.0",
+        "grunt-legacy-util": "~1.1.1",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.5.2",
+        "minimatch": "~3.0.2",
+        "mkdirp": "~0.5.1",
+        "nopt": "~3.0.6",
+        "path-is-absolute": "~1.0.0",
+        "rimraf": "~2.6.2"
+      },
+      "dependencies": {
+        "grunt-cli": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+          "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
+          "dev": true,
+          "requires": {
+            "findup-sync": "~0.3.0",
+            "grunt-known-options": "~1.1.0",
+            "nopt": "~3.0.6",
+            "resolve": "~1.1.0"
+          }
+        }
       }
     },
     "grunt-contrib-concat": {
@@ -295,71 +926,94 @@
       "integrity": "sha1-yX64lDYS/vu3L749Mu+VIzxfouk=",
       "dev": true
     },
+    "grunt-known-options": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
+      "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
+      "dev": true
+    },
     "grunt-legacy-log": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
-      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
+      "integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "grunt-legacy-log-utils": "0.1.1",
-        "hooker": "0.2.3",
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-          "dev": true
-        }
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~2.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.5"
       }
     },
     "grunt-legacy-log-utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
-      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
+      "integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-          "dev": true
-        }
+        "chalk": "~2.4.1",
+        "lodash": "~4.17.10"
       }
     },
     "grunt-legacy-util": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
-      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
+      "integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "exit": "0.1.2",
-        "getobject": "0.1.0",
-        "hooker": "0.2.3",
-        "lodash": "0.9.2",
-        "underscore.string": "2.2.1",
-        "which": "1.0.9"
+        "async": "~1.5.2",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.10",
+        "underscore.string": "~3.3.4",
+        "which": "~1.3.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
       }
     },
     "hooker": {
@@ -368,16 +1022,225 @@
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
       "dev": true
     },
-    "iconv-lite": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.0"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "jison": {
@@ -389,10 +1252,10 @@
         "JSONSelect": "0.4.0",
         "cjson": "0.3.0",
         "ebnf-parser": "0.1.10",
-        "escodegen": "1.3.3",
-        "esprima": "1.1.1",
-        "jison-lex": "0.3.4",
-        "lex-parser": "0.1.4",
+        "escodegen": "1.3.x",
+        "esprima": "1.1.x",
+        "jison-lex": "0.3.x",
+        "lex-parser": "~0.1.3",
         "nomnom": "1.5.2"
       },
       "dependencies": {
@@ -410,18 +1273,24 @@
       "integrity": "sha1-gcoo2E+ESZ36jFlNzePYo/Jux6U=",
       "dev": true,
       "requires": {
-        "lex-parser": "0.1.4",
+        "lex-parser": "0.1.x",
         "nomnom": "1.5.2"
       }
     },
+    "js-reporters": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.1.tgz",
+      "integrity": "sha1-+IxgjjJKM3OpW8xFrTBeXJecRZs=",
+      "dev": true
+    },
     "js-yaml": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
+      "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
       "dev": true,
       "requires": {
-        "argparse": "0.1.16",
-        "esprima": "1.0.4"
+        "argparse": "^1.0.2",
+        "esprima": "^2.6.0"
       }
     },
     "jsonlint": {
@@ -430,9 +1299,15 @@
       "integrity": "sha1-iKpGvCiaesk7tGyuLVihh6m7SUo=",
       "dev": true,
       "requires": {
-        "JSV": "4.0.2",
-        "nomnom": "1.5.2"
+        "JSV": ">= 4.0.x",
+        "nomnom": ">= 1.5.x"
       }
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
     },
     "lex-parser": {
       "version": "0.1.4",
@@ -440,27 +1315,208 @@
       "integrity": "sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA=",
       "dev": true
     },
-    "lodash": {
-      "version": "0.9.2",
-      "resolved": "http://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.x"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "matcher-collection": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
+      "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      }
+    },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
     },
     "nomnom": {
       "version": "1.5.2",
@@ -468,8 +1524,8 @@
       "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
       "dev": true,
       "requires": {
-        "colors": "0.5.1",
-        "underscore": "1.1.7"
+        "colors": "0.5.x",
+        "underscore": "1.1.x"
       },
       "dependencies": {
         "colors": {
@@ -487,46 +1543,565 @@
       }
     },
     "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "qunit": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-0.5.18.tgz",
-      "integrity": "sha1-mIUJybn3raOqoXsR6JcQtvBK/rM=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.8.0.tgz",
+      "integrity": "sha512-bT7vvvE4Xvk6c/uSbvP11uZXlzPJINURQyG9zj5I0EXXycW9oeDCodvAOK3GuYZ+GoXiTAMsxVSXCPGeXlTWzg==",
       "dev": true,
       "requires": {
-        "argsparser": "0.0.6",
-        "bunker": "0.1.2",
-        "cli-table": "0.0.2",
-        "tracejs": "0.1.4",
-        "underscore": "1.3.3"
+        "commander": "2.12.2",
+        "exists-stat": "1.0.0",
+        "findup-sync": "2.0.0",
+        "js-reporters": "1.2.1",
+        "resolve": "1.5.0",
+        "sane": "^4.0.0",
+        "walk-sync": "0.3.2"
       },
       "dependencies": {
-        "underscore": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz",
-          "integrity": "sha1-R6xTaD2vgyv6lS4XdEF9pHgXrkI=",
+        "findup-sync": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+          "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+          "dev": true,
+          "requires": {
+            "detect-file": "^1.0.0",
+            "is-glob": "^3.1.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
+          }
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        }
+      }
+    },
+    "qunit-assert-close": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/qunit-assert-close/-/qunit-assert-close-2.1.2.tgz",
+      "integrity": "sha1-cC1pSSr1kBCi5AQN1k/gzS4EPuE=",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5"
+      }
+    },
+    "rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sane": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-4.0.2.tgz",
+      "integrity": "sha512-/3STCUfNSgMVpoREJc1i6ajKFlYZ5OflzZTOhlqPLa+01Ey+QR9iGZK7K5/qIRsQbEDCvqEJH/PL7yZywmnWsA==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "capture-exit": "^1.2.0",
+        "exec-sh": "^0.3.2",
+        "execa": "^1.0.0",
+        "fb-watchman": "^2.0.0",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.18.0"
+      }
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
     },
-    "rimraf": {
-      "version": "2.2.8",
-      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-      "dev": true
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "source-map": {
       "version": "0.1.43",
@@ -535,28 +2110,182 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
-    "tracejs": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/tracejs/-/tracejs-0.1.4.tgz",
-      "integrity": "sha1-KdvrSuEHiS92VIzfob6OGnN1jeY=",
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "traverse": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
-      "integrity": "sha1-4gPFjV9/DjfbbnTArLkpuwm2HYU=",
+    "spdx-correct": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
     },
-    "uglify-js": {
-      "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
-      "integrity": "sha1-7nGpfEzv0GoamyBDfzQRiYKqA1s=",
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
+      "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
     },
     "underscore": {
       "version": "1.5.2",
@@ -564,15 +2293,171 @@
       "integrity": "sha1-EzXF5PXm0zu7SwBrqMhqAPVW3gg="
     },
     "underscore.string": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
+        }
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "walk-sync": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
+      "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
+      "dev": true,
+      "requires": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
+    },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.x"
+      }
+    },
+    "watch": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+      "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "exec-sh": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+          "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+          "dev": true,
+          "requires": {
+            "merge": "^1.2.0"
+          }
+        }
+      }
+    },
     "which": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
     "underscore": "~1.5.1"
   },
   "devDependencies": {
-    "jison": "0.4.15",
-    "qunit": "~0.5.16",
-    "grunt": "~0.4.0",
+    "grunt": "^1.0.3",
     "grunt-contrib-concat": "~0.1.3",
-    "grunt-execute": "~0.1.5"
+    "grunt-execute": "~0.1.5",
+    "jison": "0.4.15",
+    "qunit": "^2.8.0",
+    "qunit-assert-close": "^2.1.2"
   }
 }

--- a/test.html
+++ b/test.html
@@ -5,9 +5,9 @@
     <title>KAS Browser Tests</title>
 
     <!-- Include QUnit -->
-    <link rel="stylesheet" href="node_modules/qunit/support/qunit/qunit/qunit.css" type="text/css" media="screen">
-    <script src="node_modules/qunit/support/qunit/qunit/qunit.js"></script>
-    <script src="node_modules/qunit/support/qunit/addons/close-enough/qunit-close-enough.js"></script>
+    <link rel="stylesheet" href="node_modules/qunit/qunit/qunit.css" type="text/css" media="screen">
+    <script src="node_modules/qunit/qunit/qunit.js"></script>
+    <script src="node_modules/qunit-assert-close/qunit-assert-close.js"></script>
 
     <!-- Include Underscore -->
     <script src="node_modules/underscore/underscore.js"></script>
@@ -43,304 +43,304 @@
 
     QUnit.module("parsing");
 
-    var print = function(input, expected, options) {
+    var print = function(assert, input, expected, options) {
         var message = input + " parses as " + expected;
-        QUnit.close(parse(input, options).print(), expected, 1e-9, message);
+        assert.close(parse(input, options).print(), expected, 1e-9, message);
     };
 
-    test("empty", function() {
-        print("", "");
+    QUnit.test("empty", function(assert) {
+        print(assert, "", "");
     });
 
-    test("positive and negative primitives", function() {
-        print("0", "0");
-        print("1.", "1");
-        print("3.14", "3.14");
-        print(".14", "0.14");
-        print("pi", "pi");
-        print("e", "e");
-        print("x", "x");
-        print("theta", "theta");
+    QUnit.test("positive and negative primitives", function(assert) {
+        print(assert, "0", "0");
+        print(assert, "1.", "1");
+        print(assert, "3.14", "3.14");
+        print(assert, ".14", "0.14");
+        print(assert, "pi", "pi");
+        print(assert, "e", "e");
+        print(assert, "x", "x");
+        print(assert, "theta", "theta");
 
-        print("-0", "-1*0");
-        print("-1.", "-1");
-        print("-3.14", "-3.14");
-        print("-.14", "-0.14");
-        print("-pi", "-1*pi");
-        print("-e", "-1*e");
-        print("-theta", "-1*theta");
+        print(assert, "-0", "-1*0");
+        print(assert, "-1.", "-1");
+        print(assert, "-3.14", "-3.14");
+        print(assert, "-.14", "-0.14");
+        print(assert, "-pi", "-1*pi");
+        print(assert, "-e", "-1*e");
+        print(assert, "-theta", "-1*theta");
     });
 
-    test("LaTeX constants", function() {
-        print("\\theta", "theta");
-        print("\\pi", "pi");
-        print("\\phi", "phi");
+    QUnit.test("LaTeX constants", function(assert) {
+        print(assert, "\\theta", "theta");
+        print(assert, "\\pi", "pi");
+        print(assert, "\\phi", "phi");
     });
 
-    test("ignore TeX spaces", function() {
-        print("a\\space b", "a*b");
-        print("a\\ b", "a*b");
+    QUnit.test("ignore TeX spaces", function(assert) {
+        print(assert, "a\\space b", "a*b");
+        print(assert, "a\\ b", "a*b");
     });
 
-    test("positive and negative rationals", function() {
-        print("1/2", "1/2");
-        print("-1/2", "-1/2");
-        print("1/-2", "-1/2");
-        print("-1/-2", "-1*-1/2");
-        print("42/42", "42/42");
-        print("42/1", "42/1");
-        print("0/42", "0/42");
+    QUnit.test("positive and negative rationals", function(assert) {
+        print(assert, "1/2", "1/2");
+        print(assert, "-1/2", "-1/2");
+        print(assert, "1/-2", "-1/2");
+        print(assert, "-1/-2", "-1*-1/2");
+        print(assert, "42/42", "42/42");
+        print(assert, "42/1", "42/1");
+        print(assert, "0/42", "0/42");
 
-        print("2 (1/2)", "2*1/2");
-        print("1/2 1/2", "1/2*1/2");
-        print("-1/2", "-1/2");
-        print("1/2 2", "1/2*2");
+        print(assert, "2 (1/2)", "2*1/2");
+        print(assert, "1/2 1/2", "1/2*1/2");
+        print(assert, "-1/2", "-1/2");
+        print(assert, "1/2 2", "1/2*2");
     });
 
-    test("rationals using \\frac", function() {
-        print("\\frac{1}{2}", "1/2");
-        print("\\frac{-1}{2}", "-1/2");
-        print("\\frac{1}{-2}", "-1/2");
-        print("\\frac{-1}{-2}", "-1*-1/2");
-        print("\\frac{42}{42}", "42/42");
-        print("\\frac{42}{1}", "42/1");
-        print("\\frac{0}{42}", "0/42");
+    QUnit.test("rationals using \\frac", function(assert) {
+        print(assert, "\\frac{1}{2}", "1/2");
+        print(assert, "\\frac{-1}{2}", "-1/2");
+        print(assert, "\\frac{1}{-2}", "-1/2");
+        print(assert, "\\frac{-1}{-2}", "-1*-1/2");
+        print(assert, "\\frac{42}{42}", "42/42");
+        print(assert, "\\frac{42}{1}", "42/1");
+        print(assert, "\\frac{0}{42}", "0/42");
 
-        print("2\\frac{1}{2}", "2*1/2");
-        print("\\frac{1}{2}\\frac{1}{2}", "1/2*1/2");
-        print("-\\frac{1}{2}", "-1/2");
-        print("\\frac{1}{2}2", "1/2*2");
+        print(assert, "2\\frac{1}{2}", "2*1/2");
+        print(assert, "\\frac{1}{2}\\frac{1}{2}", "1/2*1/2");
+        print(assert, "-\\frac{1}{2}", "-1/2");
+        print(assert, "\\frac{1}{2}2", "1/2*2");
     });
 
-    test("rationals using \\dfrac", function() {
-        print("\\dfrac{1}{2}", "1/2");
-        print("\\dfrac{-1}{2}", "-1/2");
-        print("\\dfrac{1}{-2}", "-1/2");
-        print("\\dfrac{-1}{-2}", "-1*-1/2");
-        print("\\dfrac{42}{42}", "42/42");
-        print("\\dfrac{42}{1}", "42/1");
-        print("\\dfrac{0}{42}", "0/42");
+    QUnit.test("rationals using \\dfrac", function(assert) {
+        print(assert, "\\dfrac{1}{2}", "1/2");
+        print(assert, "\\dfrac{-1}{2}", "-1/2");
+        print(assert, "\\dfrac{1}{-2}", "-1/2");
+        print(assert, "\\dfrac{-1}{-2}", "-1*-1/2");
+        print(assert, "\\dfrac{42}{42}", "42/42");
+        print(assert, "\\dfrac{42}{1}", "42/1");
+        print(assert, "\\dfrac{0}{42}", "0/42");
 
-        print("2\\dfrac{1}{2}", "2*1/2");
-        print("\\dfrac{1}{2}\\dfrac{1}{2}", "1/2*1/2");
-        print("-\\dfrac{1}{2}", "-1/2");
-        print("\\dfrac{1}{2}2", "1/2*2");
+        print(assert, "2\\dfrac{1}{2}", "2*1/2");
+        print(assert, "\\dfrac{1}{2}\\dfrac{1}{2}", "1/2*1/2");
+        print(assert, "-\\dfrac{1}{2}", "-1/2");
+        print(assert, "\\dfrac{1}{2}2", "1/2*2");
     });
 
-    test("parens", function() {
-        print("(0)", "0");
-        print("(ab)", "a*b");
-        print("(a/b)", "a*b^(-1)");
-        print("(a^b)", "a^(b)");
-        print("(ab)c", "a*b*c");
-        print("a(bc)", "a*b*c");
-        print("a+(b+c)", "a+b+c");
-        print("(a+b)+c", "a+b+c");
-        print("a(b+c)", "a*(b+c)");
-        print("(a+b)^c", "(a+b)^(c)");
-        print("(ab)^c", "(a*b)^(c)");
+    QUnit.test("parens", function(assert) {
+        print(assert, "(0)", "0");
+        print(assert, "(ab)", "a*b");
+        print(assert, "(a/b)", "a*b^(-1)");
+        print(assert, "(a^b)", "a^(b)");
+        print(assert, "(ab)c", "a*b*c");
+        print(assert, "a(bc)", "a*b*c");
+        print(assert, "a+(b+c)", "a+b+c");
+        print(assert, "(a+b)+c", "a+b+c");
+        print(assert, "a(b+c)", "a*(b+c)");
+        print(assert, "(a+b)^c", "(a+b)^(c)");
+        print(assert, "(ab)^c", "(a*b)^(c)");
     });
 
-    test("subscripts", function() {
-        print("a", "a");
-        print("a_0", "a_(0)");
-        print("a_i", "a_(i)");
-        print("a_n", "a_(n)");
-        print("a_n+1", "a_(n)+1");
-        print("a_(n+1)", "a_(n+1)");
-        print("a_{n+1}", "a_(n+1)");
+    QUnit.test("subscripts", function(assert) {
+        print(assert, "a", "a");
+        print(assert, "a_0", "a_(0)");
+        print(assert, "a_i", "a_(i)");
+        print(assert, "a_n", "a_(n)");
+        print(assert, "a_n+1", "a_(n)+1");
+        print(assert, "a_(n+1)", "a_(n+1)");
+        print(assert, "a_{n+1}", "a_(n+1)");
     });
 
-    test("negation", function() {
-        print("-x", "-1*x");
-        print("--x", "-1*-1*x");
-        print("---x", "-1*-1*-1*x");
-        print("-1", "-1");
-        print("--1", "-1*-1");
-        print("---1", "-1*-1*-1");
-        print("-3x", "-3*x");
-        print("--3x", "-1*-3*x");
-        print("-x*3", "x*-3");
-        print("--x*3", "-1*x*-3");
-        print("\u2212x", "-1*x");
+    QUnit.test("negation", function(assert) {
+        print(assert, "-x", "-1*x");
+        print(assert, "--x", "-1*-1*x");
+        print(assert, "---x", "-1*-1*-1*x");
+        print(assert, "-1", "-1");
+        print(assert, "--1", "-1*-1");
+        print(assert, "---1", "-1*-1*-1");
+        print(assert, "-3x", "-3*x");
+        print(assert, "--3x", "-1*-3*x");
+        print(assert, "-x*3", "x*-3");
+        print(assert, "--x*3", "-1*x*-3");
+        print(assert, "\u2212x", "-1*x");
     });
 
-    test("addition and subtraction", function() {
-        print("a+b", "a+b");
-        print("a-b", "a+-1*b");
-        print("a--b", "a+-1*-1*b");
-        print("a---b", "a+-1*-1*-1*b");
-        print("2-4", "2+-4");
-        print("2--4", "2+-1*-4");
-        print("2---4", "2+-1*-1*-4");
-        print("2-x*4", "2+x*-4");
-        print("1-2+a-b+pi-e", "1+-2+a+-1*b+pi+-1*e");
-        print("x+1", "x+1");
-        print("x-1", "x+-1");
-        print("(x-1)", "x+-1");
-        print("a(x-1)", "a*(x+-1)");
-        print("a\u2212b", "a+-1*b");
+    QUnit.test("addition and subtraction", function(assert) {
+        print(assert, "a+b", "a+b");
+        print(assert, "a-b", "a+-1*b");
+        print(assert, "a--b", "a+-1*-1*b");
+        print(assert, "a---b", "a+-1*-1*-1*b");
+        print(assert, "2-4", "2+-4");
+        print(assert, "2--4", "2+-1*-4");
+        print(assert, "2---4", "2+-1*-1*-4");
+        print(assert, "2-x*4", "2+x*-4");
+        print(assert, "1-2+a-b+pi-e", "1+-2+a+-1*b+pi+-1*e");
+        print(assert, "x+1", "x+1");
+        print(assert, "x-1", "x+-1");
+        print(assert, "(x-1)", "x+-1");
+        print(assert, "a(x-1)", "a*(x+-1)");
+        print(assert, "a\u2212b", "a+-1*b");
     });
 
-    test("multiplication", function() {
-        print("a*b", "a*b");
-        print("-a*b", "-1*a*b");
-        print("a*-b", "a*-1*b");
-        print("-ab", "-1*a*b");
-        print("-a*b", "-1*a*b");
-        print("-(ab)", "-1*a*b");
-        print("a\u00b7b", "a*b");
-        print("a\u00d7b", "a*b");
-        print("a\\cdotb", "a*b");
-        print("a\\timesb", "a*b");
-        print("a\\astb", "a*b");
+    QUnit.test("multiplication", function(assert) {
+        print(assert, "a*b", "a*b");
+        print(assert, "-a*b", "-1*a*b");
+        print(assert, "a*-b", "a*-1*b");
+        print(assert, "-ab", "-1*a*b");
+        print(assert, "-a*b", "-1*a*b");
+        print(assert, "-(ab)", "-1*a*b");
+        print(assert, "a\u00b7b", "a*b");
+        print(assert, "a\u00d7b", "a*b");
+        print(assert, "a\\cdotb", "a*b");
+        print(assert, "a\\timesb", "a*b");
+        print(assert, "a\\astb", "a*b");
     })
 
-    test("division", function() {
-        print("a/b", "a*b^(-1)");
-        print("a/bc", "a*b^(-1)*c");
-        print("(ab)/c", "a*b*c^(-1)");
-        print("ab/c", "a*b*c^(-1)");
-        print("ab/cd", "a*b*c^(-1)*d");
-        print("a\\divb", "a*b^(-1)");
-        print("a\u00F7b", "a*b^(-1)");
+    QUnit.test("division", function(assert) {
+        print(assert, "a/b", "a*b^(-1)");
+        print(assert, "a/bc", "a*b^(-1)*c");
+        print(assert, "(ab)/c", "a*b*c^(-1)");
+        print(assert, "ab/c", "a*b*c^(-1)");
+        print(assert, "ab/cd", "a*b*c^(-1)*d");
+        print(assert, "a\\divb", "a*b^(-1)");
+        print(assert, "a\u00F7b", "a*b^(-1)");
     });
 
-    test("exponentiation", function() {
-        print("x^y", "x^(y)");
-        print("x^y^z", "x^(y^(z))");
-        print("x^yz", "x^(y)*z");
-        print("-x^2", "-1*x^(2)");
-        print("-(x^2)", "-1*x^(2)");
-        print("0-x^2", "0+-1*x^(2)");
-        print("x^-y", "x^(-1*y)");
-        print("x^(-y)", "x^(-1*y)");
-        print("x^-(y)", "x^(-1*y)");
-        print("x^-(-y)", "x^(-1*-1*y)");
-        print("x^--y", "x^(-1*-1*y)");
-        print("x^-yz", "x^(-1*y)*z");
-        print("x^-y^z", "x^(-1*y^(z))");
-        print("x**y", "x^(y)");
+    QUnit.test("exponentiation", function(assert) {
+        print(assert, "x^y", "x^(y)");
+        print(assert, "x^y^z", "x^(y^(z))");
+        print(assert, "x^yz", "x^(y)*z");
+        print(assert, "-x^2", "-1*x^(2)");
+        print(assert, "-(x^2)", "-1*x^(2)");
+        print(assert, "0-x^2", "0+-1*x^(2)");
+        print(assert, "x^-y", "x^(-1*y)");
+        print(assert, "x^(-y)", "x^(-1*y)");
+        print(assert, "x^-(y)", "x^(-1*y)");
+        print(assert, "x^-(-y)", "x^(-1*-1*y)");
+        print(assert, "x^--y", "x^(-1*-1*y)");
+        print(assert, "x^-yz", "x^(-1*y)*z");
+        print(assert, "x^-y^z", "x^(-1*y^(z))");
+        print(assert, "x**y", "x^(y)");
 
-        print("x^{a}", "x^(a)");
-        print("x^{ab}", "x^(a*b)");
+        print(assert, "x^{a}", "x^(a)");
+        print(assert, "x^{ab}", "x^(a*b)");
     });
 
-    test("square root", function() {
-        print("sqrt(x)", "x^(1/2)");
-        print("sqrt(x)y", "x^(1/2)*y");
-        print("1/sqrt(x)", "x^(-1/2)");
-        print("1/sqrt(x)y", "x^(-1/2)*y");
+    QUnit.test("square root", function(assert) {
+        print(assert, "sqrt(x)", "x^(1/2)");
+        print(assert, "sqrt(x)y", "x^(1/2)*y");
+        print(assert, "1/sqrt(x)", "x^(-1/2)");
+        print(assert, "1/sqrt(x)y", "x^(-1/2)*y");
 
-        print("sqrt(2)/2", "2^(1/2)*1/2");
-        print("sqrt(2)^2", "(2^(1/2))^(2)");
+        print(assert, "sqrt(2)/2", "2^(1/2)*1/2");
+        print(assert, "sqrt(2)^2", "(2^(1/2))^(2)");
 
-        print("\\sqrt(x)", "x^(1/2)");
-        print("\\sqrt(x)y", "x^(1/2)*y");
-        print("1/\\sqrt(x)", "x^(-1/2)");
-        print("1/\\sqrt(x)y", "x^(-1/2)*y");
+        print(assert, "\\sqrt(x)", "x^(1/2)");
+        print(assert, "\\sqrt(x)y", "x^(1/2)*y");
+        print(assert, "1/\\sqrt(x)", "x^(-1/2)");
+        print(assert, "1/\\sqrt(x)y", "x^(-1/2)*y");
 
-        print("\\sqrt(2)/2", "2^(1/2)*1/2");
-        print("\\sqrt(2)^2", "(2^(1/2))^(2)");
+        print(assert, "\\sqrt(2)/2", "2^(1/2)*1/2");
+        print(assert, "\\sqrt(2)^2", "(2^(1/2))^(2)");
 
-        print("\\sqrt{2}", "2^(1/2)");
-        print("\\sqrt{2+2}", "(2+2)^(1/2)");
+        print(assert, "\\sqrt{2}", "2^(1/2)");
+        print(assert, "\\sqrt{2+2}", "(2+2)^(1/2)");
     });
 
-    test("nth root", function() {
-        print("sqrt[3]{x}", "x^(1/3)");
-        print("sqrt[4]{x}y", "x^(1/4)*y");
-        print("1/sqrt[5]{x}", "x^(-1/5)");
-        print("1/sqrt[7]{x}y", "x^(-1/7)*y");
+    QUnit.test("nth root", function(assert) {
+        print(assert, "sqrt[3]{x}", "x^(1/3)");
+        print(assert, "sqrt[4]{x}y", "x^(1/4)*y");
+        print(assert, "1/sqrt[5]{x}", "x^(-1/5)");
+        print(assert, "1/sqrt[7]{x}y", "x^(-1/7)*y");
 
-        print("sqrt[3]{2}/2", "2^(1/3)*1/2");
-        print("sqrt[3]{2}^2", "(2^(1/3))^(2)");
+        print(assert, "sqrt[3]{2}/2", "2^(1/3)*1/2");
+        print(assert, "sqrt[3]{2}^2", "(2^(1/3))^(2)");
 
-        print("\\sqrt[4]{x}", "x^(1/4)");
-        print("\\sqrt[4]{x}y", "x^(1/4)*y");
-        print("1/\\sqrt[4]{x}", "x^(-1/4)");
-        print("1/\\sqrt[4]{x}y", "x^(-1/4)*y");
+        print(assert, "\\sqrt[4]{x}", "x^(1/4)");
+        print(assert, "\\sqrt[4]{x}y", "x^(1/4)*y");
+        print(assert, "1/\\sqrt[4]{x}", "x^(-1/4)");
+        print(assert, "1/\\sqrt[4]{x}y", "x^(-1/4)*y");
 
-        print("\\sqrt[5]{2}/2", "2^(1/5)*1/2");
-        print("\\sqrt[5]{2}^2", "(2^(1/5))^(2)");
+        print(assert, "\\sqrt[5]{2}/2", "2^(1/5)*1/2");
+        print(assert, "\\sqrt[5]{2}^2", "(2^(1/5))^(2)");
 
-        print("\\sqrt[6]{2}", "2^(1/6)");
-        print("\\sqrt[6]{2+2}", "(2+2)^(1/6)");
+        print(assert, "\\sqrt[6]{2}", "2^(1/6)");
+        print(assert, "\\sqrt[6]{2+2}", "(2+2)^(1/6)");
 
-        print("\\sqrt[2]{2}", "2^(1/2)");
-        print("\\sqrt[2]{2+2}", "(2+2)^(1/2)");
+        print(assert, "\\sqrt[2]{2}", "2^(1/2)");
+        print(assert, "\\sqrt[2]{2+2}", "(2+2)^(1/2)");
     });
 
-    test("absolute value", function() {
-        print("abs(x)", "abs(x)");
-        print("abs(abs(x))", "abs(abs(x))");
-        print("abs(x)abs(y)", "abs(x)*abs(y)");
+    QUnit.test("absolute value", function(assert) {
+        print(assert, "abs(x)", "abs(x)");
+        print(assert, "abs(abs(x))", "abs(abs(x))");
+        print(assert, "abs(x)abs(y)", "abs(x)*abs(y)");
 
-        print("|x|", "abs(x)");
-        print("||x||", "abs(abs(x))");
+        print(assert, "|x|", "abs(x)");
+        print(assert, "||x||", "abs(abs(x))");
         // TODO(alex): fix the below so it doesn't require an *
         // may require own lexer/preprocessor
-        print("|x|*|y|", "abs(x)*abs(y)");
+        print(assert, "|x|*|y|", "abs(x)*abs(y)");
 
-        print("\\abs(x)", "abs(x)");
-        print("\\abs(\\abs(x))", "abs(abs(x))");
-        print("\\abs(x)\\abs(y)", "abs(x)*abs(y)");
+        print(assert, "\\abs(x)", "abs(x)");
+        print(assert, "\\abs(\\abs(x))", "abs(abs(x))");
+        print(assert, "\\abs(x)\\abs(y)", "abs(x)*abs(y)");
 
-        print("\\left|x\\right|", "abs(x)");
-        print("\\left|\\left|x\\right|\\right|", "abs(abs(x))");
-        print("\\left|x\\right|\\left|y\\right|", "abs(x)*abs(y)");
+        print(assert, "\\left|x\\right|", "abs(x)");
+        print(assert, "\\left|\\left|x\\right|\\right|", "abs(abs(x))");
+        print(assert, "\\left|x\\right|\\left|y\\right|", "abs(x)*abs(y)");
     });
 
-    test("logarithms", function() {
-        print("lnx", "ln(x)");
-        print("ln x", "ln(x)");
-        print("ln x^y", "ln(x^(y))");
-        print("ln xy", "ln(x*y)");
-        print("ln x/y", "ln(x*y^(-1))");
-        print("ln x+y", "ln(x)+y");
-        print("ln x-y", "ln(x)+-1*y");
+    QUnit.test("logarithms", function(assert) {
+        print(assert, "lnx", "ln(x)");
+        print(assert, "ln x", "ln(x)");
+        print(assert, "ln x^y", "ln(x^(y))");
+        print(assert, "ln xy", "ln(x*y)");
+        print(assert, "ln x/y", "ln(x*y^(-1))");
+        print(assert, "ln x+y", "ln(x)+y");
+        print(assert, "ln x-y", "ln(x)+-1*y");
 
-        print("ln xyz", "ln(x*y*z)");
-        print("ln xy/z", "ln(x*y*z^(-1))");
-        print("ln xy/z+1", "ln(x*y*z^(-1))+1");
+        print(assert, "ln xyz", "ln(x*y*z)");
+        print(assert, "ln xy/z", "ln(x*y*z^(-1))");
+        print(assert, "ln xy/z+1", "ln(x*y*z^(-1))+1");
 
-        print("ln x(y)", "ln(x)*y");
+        print(assert, "ln x(y)", "ln(x)*y");
 
-        print("logx", "log_(10) (x)");
-        print("log x", "log_(10) (x)");
-        print("log_2x", "log_(2) (x)");
-        print("log _ 2 x", "log_(2) (x)");
-        print("log_bx_0", "log_(b) (x_(0))");
-        print("log_x_0b", "log_(x_(0)) (b)");
+        print(assert, "logx", "log_(10) (x)");
+        print(assert, "log x", "log_(10) (x)");
+        print(assert, "log_2x", "log_(2) (x)");
+        print(assert, "log _ 2 x", "log_(2) (x)");
+        print(assert, "log_bx_0", "log_(b) (x_(0))");
+        print(assert, "log_x_0b", "log_(x_(0)) (b)");
 
-        print("log_2.5x", "log_(2.5) (x)");
+        print(assert, "log_2.5x", "log_(2.5) (x)");
 
-        print("ln ln x", "ln(ln(x))");
-        print("ln x ln y", "ln(x)*ln(y)");
-        print("ln x/ln y", "ln(x)*ln(y)^(-1)");
+        print(assert, "ln ln x", "ln(ln(x))");
+        print(assert, "ln x ln y", "ln(x)*ln(y)");
+        print(assert, "ln x/ln y", "ln(x)*ln(y)^(-1)");
 
-        print("\\lnx", "ln(x)");
-        print("\\ln x", "ln(x)");
-        print("\\ln x^y", "ln(x^(y))");
-        print("\\ln xy", "ln(x*y)");
-        print("\\ln x/y", "ln(x*y^(-1))");
-        print("\\ln x+y", "ln(x)+y");
-        print("\\ln x-y", "ln(x)+-1*y");
+        print(assert, "\\lnx", "ln(x)");
+        print(assert, "\\ln x", "ln(x)");
+        print(assert, "\\ln x^y", "ln(x^(y))");
+        print(assert, "\\ln xy", "ln(x*y)");
+        print(assert, "\\ln x/y", "ln(x*y^(-1))");
+        print(assert, "\\ln x+y", "ln(x)+y");
+        print(assert, "\\ln x-y", "ln(x)+-1*y");
 
-        print("\\logx", "log_(10) (x)");
-        print("\\log x", "log_(10) (x)");
-        print("\\log_2x", "log_(2) (x)");
-        print("\\log _ 2 x", "log_(2) (x)");
-        print("\\log_bx_0", "log_(b) (x_(0))");
-        print("\\log_x_0b", "log_(x_(0)) (b)");
+        print(assert, "\\logx", "log_(10) (x)");
+        print(assert, "\\log x", "log_(10) (x)");
+        print(assert, "\\log_2x", "log_(2) (x)");
+        print(assert, "\\log _ 2 x", "log_(2) (x)");
+        print(assert, "\\log_bx_0", "log_(b) (x_(0))");
+        print(assert, "\\log_x_0b", "log_(x_(0)) (b)");
 
-        print("\\log_2.5x", "log_(2.5) (x)");
+        print(assert, "\\log_2.5x", "log_(2.5) (x)");
 
-        print("\\frac{\\logx}{y}", "log_(10) (x)*y^(-1)");
-        print("\\frac{\\log x}{y}", "log_(10) (x)*y^(-1)");
+        print(assert, "\\frac{\\logx}{y}", "log_(10) (x)*y^(-1)");
+        print(assert, "\\frac{\\log x}{y}", "log_(10) (x)*y^(-1)");
     });
 
-    test("trig functions", function() {
+    QUnit.test("trig functions", function(assert) {
         var functions = [
             "sin", "cos", "tan",
             "csc", "sec", "cot"
@@ -351,351 +351,351 @@
         });
 
         _.each(functions.concat(inverses), function(func) {
-            print(func + "x", func + "(x)");
-            print("\\" + func + "x", func + "(x)");
+            print(assert, func + "x", func + "(x)");
+            print(assert, "\\" + func + "x", func + "(x)");
         });
 
-        print("sin^-1 x", "arcsin(x)");
-        print("\\sin^-1 x", "arcsin(x)");
+        print(assert, "sin^-1 x", "arcsin(x)");
+        print(assert, "\\sin^-1 x", "arcsin(x)");
 
-        print("(sinx)^2", "sin(x)^(2)");
-        print("sin^2x", "sin(x)^(2)");
-        print("sin^2(x)", "sin(x)^(2)");
-        print("sin^2 x", "sin(x)^(2)");
-        print("(sin^2x)", "sin(x)^(2)");
+        print(assert, "(sinx)^2", "sin(x)^(2)");
+        print(assert, "sin^2x", "sin(x)^(2)");
+        print(assert, "sin^2(x)", "sin(x)^(2)");
+        print(assert, "sin^2 x", "sin(x)^(2)");
+        print(assert, "(sin^2x)", "sin(x)^(2)");
 
-        print("sin xy", "sin(x*y)");
-        print("sin x(y)", "sin(x)*y");
-        print("sin x/y", "sin(x*y^(-1))");
-        print("(sin x)/y", "sin(x)*y^(-1)");
+        print(assert, "sin xy", "sin(x*y)");
+        print(assert, "sin x(y)", "sin(x)*y");
+        print(assert, "sin x/y", "sin(x*y^(-1))");
+        print(assert, "(sin x)/y", "sin(x)*y^(-1)");
 
-        print("sin sin x", "sin(sin(x))");
-        print("sin x sin y", "sin(x)*sin(y)");
-        print("sin x/sin y", "sin(x)*sin(y)^(-1)");
+        print(assert, "sin sin x", "sin(sin(x))");
+        print(assert, "sin x sin y", "sin(x)*sin(y)");
+        print(assert, "sin x/sin y", "sin(x)*sin(y)^(-1)");
 
-        print("1/(sinx)^2", "sin(x)^(-2)");
-        print("1/sin^2x", "sin(x)^(-2)");
-        print("1/sin^2(x)", "sin(x)^(-2)");
-        print("1/(sin^2x)", "sin(x)^(-2)");
+        print(assert, "1/(sinx)^2", "sin(x)^(-2)");
+        print(assert, "1/sin^2x", "sin(x)^(-2)");
+        print(assert, "1/sin^2(x)", "sin(x)^(-2)");
+        print(assert, "1/(sin^2x)", "sin(x)^(-2)");
 
-        print("sin(theta)", "sin(theta)");
-        print("\\sin(\\theta)", "sin(theta)");
+        print(assert, "sin(theta)", "sin(theta)");
+        print(assert, "\\sin(\\theta)", "sin(theta)");
     });
 
-    test("hyperbolic functions", function() {
-        print("sinh xy", "sinh(x*y)");
-        print("1/(sinhx)^2", "sinh(x)^(-2)");
-        print("\\sinh(\\theta)", "sinh(theta)");
+    QUnit.test("hyperbolic functions", function(assert) {
+        print(assert, "sinh xy", "sinh(x*y)");
+        print(assert, "1/(sinhx)^2", "sinh(x)^(-2)");
+        print(assert, "\\sinh(\\theta)", "sinh(theta)");
     });
 
-    test("formulas", function() {
-        print("mx+b", "m*x+b");
-        print("v^2/r", "v^(2)*r^(-1)");
-        print("4/3pir^3", "4/3*pi*r^(3)");
-        print("4/3\u03C0r^3", "4/3*pi*r^(3)");
-        print("sin^2 x + cos^2 x = 1", "sin(x)^(2)+cos(x)^(2)=1");
+    QUnit.test("formulas", function(assert) {
+        print(assert, "mx+b", "m*x+b");
+        print(assert, "v^2/r", "v^(2)*r^(-1)");
+        print(assert, "4/3pir^3", "4/3*pi*r^(3)");
+        print(assert, "4/3\u03C0r^3", "4/3*pi*r^(3)");
+        print(assert, "sin^2 x + cos^2 x = 1", "sin(x)^(2)+cos(x)^(2)=1");
     });
 
-    test("factors", function() {
-        print("(6x+1)(x-1)", "(6*x+1)*(x+-1)");
+    QUnit.test("factors", function(assert) {
+        print(assert, "(6x+1)(x-1)", "(6*x+1)*(x+-1)");
     });
 
-    test("whitespace", function() {
-        print("12/3", "12/3");
-        print("12 /3", "12/3");
-        print("12/ 3", "12/3");
-        print("xy", "x*y");
-        print("x y", "x*y");
+    QUnit.test("whitespace", function(assert) {
+        print(assert, "12/3", "12/3");
+        print(assert, "12 /3", "12/3");
+        print(assert, "12/ 3", "12/3");
+        print(assert, "xy", "x*y");
+        print(assert, "x y", "x*y");
     });
 
-    test("equations", function() {
-        print("y=x", "y=x");
-        print("y=x^2", "y=x^(2)");
-        print("1<2", "1<2");
-        print("1<=2", "1<=2");
-        print("1\\le2", "1<=2");
-        print("2>1", "2>1");
-        print("2>=1", "2>=1");
-        print("2\\ge1", "2>=1");
-        print("1<>2", "1<>2");
-        print("1=/=2", "1<>2");
-        print("1\\ne2", "1<>2");
-        print("1\\neq2", "1<>2");
-        print("a\u2260b", "a<>b");
-        print("a\u2264b", "a<=b");
-        print("a\u2265b", "a>=b");
+    QUnit.test("equations", function(assert) {
+        print(assert, "y=x", "y=x");
+        print(assert, "y=x^2", "y=x^(2)");
+        print(assert, "1<2", "1<2");
+        print(assert, "1<=2", "1<=2");
+        print(assert, "1\\le2", "1<=2");
+        print(assert, "2>1", "2>1");
+        print(assert, "2>=1", "2>=1");
+        print(assert, "2\\ge1", "2>=1");
+        print(assert, "1<>2", "1<>2");
+        print(assert, "1=/=2", "1<>2");
+        print(assert, "1\\ne2", "1<>2");
+        print(assert, "1\\neq2", "1<>2");
+        print(assert, "a\u2260b", "a<>b");
+        print(assert, "a\u2264b", "a<=b");
+        print(assert, "a\u2265b", "a>=b");
     });
 
-    test("function variables", function() {
-        print("f(x)", "f*x");
-        print("f(x)", "f(x)", {functions: ["f"]});
-        print("f(x+y)", "f(x+y)", {functions: ["f"]});
-        print("f(x)g(x)", "f(x)*g(x)", {functions: ["f", "g"]});
-        print("f(g(h(x)))", "f(g(h(x)))", {functions: ["f", "g", "h"]});
+    QUnit.test("function variables", function(assert) {
+        print(assert, "f(x)", "f*x");
+        print(assert, "f(x)", "f(x)", {functions: ["f"]});
+        print(assert, "f(x+y)", "f(x+y)", {functions: ["f"]});
+        print(assert, "f(x)g(x)", "f(x)*g(x)", {functions: ["f", "g"]});
+        print(assert, "f(g(h(x)))", "f(g(h(x)))", {functions: ["f", "g", "h"]});
 
-        print("f\\left(x\\right)", "f*x");
-        print("f\\left(x\\right)", "f(x)", {functions: ["f"]});
-        print("f\\left(x+y\\right)", "f(x+y)", {functions: ["f"]});
-        print("f\\left(x\\right)g\\left(x\\right)", "f(x)*g(x)", {functions: ["f", "g"]});
-        print("f\\left(g\\left(h\\left(x\\right)\\right)\\right)", "f(g(h(x)))", {functions: ["f", "g", "h"]});
+        print(assert, "f\\left(x\\right)", "f*x");
+        print(assert, "f\\left(x\\right)", "f(x)", {functions: ["f"]});
+        print(assert, "f\\left(x+y\\right)", "f(x+y)", {functions: ["f"]});
+        print(assert, "f\\left(x\\right)g\\left(x\\right)", "f(x)*g(x)", {functions: ["f", "g"]});
+        print(assert, "f\\left(g\\left(h\\left(x\\right)\\right)\\right)", "f(g(h(x)))", {functions: ["f", "g", "h"]});
     });
 
-    var repr = function(input, expected, options) {
+    var repr = function(assert, input, expected, options) {
         var message = input + " parses as " + expected;
-        strictEqual(parse(input, options).repr(), expected, message);
+        assert.strictEqual(parse(input, options).repr(), expected, message);
     };
 
-    test("structure", function() {
-        repr("", "Add()");
-        repr("1.", "1");
-        repr("1/2", "1/2");
-        repr("1/-2", "-1/2");
-        repr("x/-2", "Mul(Var(x),-1/2)");
-        repr("a+b", "Add(Var(a),Var(b))");
-        repr("a+b+c", "Add(Var(a),Var(b),Var(c))");
-        repr("a-b", "Add(Var(a),Mul(-1,Var(b)))");
-        repr("a-b+c", "Add(Var(a),Mul(-1,Var(b)),Var(c))");
-        repr("abc", "Mul(Var(a),Var(b),Var(c))");
-        repr("a/bc", "Mul(Var(a),Pow(Var(b),-1),Var(c))");
-        repr("a*(b+c)", "Mul(Var(a),Add(Var(b),Var(c)))");
-        repr("x--y", "Add(Var(x),Mul(-1,-1,Var(y)))");
-        repr("--y", "Mul(-1,-1,Var(y))");
-        repr("e", "Const(e)");
-        repr("2e", "Mul(2,Const(e))");
-        repr("2e^x", "Mul(2,Pow(Const(e),Var(x)))");
-        repr("cdef", "Mul(Var(c),Var(d),Const(e),Var(f))");
-        repr("pi", "Const(pi)");
-        repr("pi^2", "Pow(Const(pi),2)")
-        repr("pir", "Mul(Const(pi),Var(r))");
-        repr("pir^2", "Mul(Const(pi),Pow(Var(r),2))");
-        repr("y=x^2", "Eq(Var(y),=,Pow(Var(x),2))");
-        repr("log_2x", "Log(2,Var(x))");
-        repr("f(x+y)", "Mul(Var(f),Add(Var(x),Var(y)))");
-        repr("f(x+y)", "Func(f,Add(Var(x),Var(y)))", {functions: ["f"]});
-        repr("sin(theta)", "Trig(sin,Var(theta))");
-        repr("tanh(theta)", "Trig(tanh,Var(theta))");
+    QUnit.test("structure", function(assert) {
+        repr(assert, "", "Add()");
+        repr(assert, "1.", "1");
+        repr(assert, "1/2", "1/2");
+        repr(assert, "1/-2", "-1/2");
+        repr(assert, "x/-2", "Mul(Var(x),-1/2)");
+        repr(assert, "a+b", "Add(Var(a),Var(b))");
+        repr(assert, "a+b+c", "Add(Var(a),Var(b),Var(c))");
+        repr(assert, "a-b", "Add(Var(a),Mul(-1,Var(b)))");
+        repr(assert, "a-b+c", "Add(Var(a),Mul(-1,Var(b)),Var(c))");
+        repr(assert, "abc", "Mul(Var(a),Var(b),Var(c))");
+        repr(assert, "a/bc", "Mul(Var(a),Pow(Var(b),-1),Var(c))");
+        repr(assert, "a*(b+c)", "Mul(Var(a),Add(Var(b),Var(c)))");
+        repr(assert, "x--y", "Add(Var(x),Mul(-1,-1,Var(y)))");
+        repr(assert, "--y", "Mul(-1,-1,Var(y))");
+        repr(assert, "e", "Const(e)");
+        repr(assert, "2e", "Mul(2,Const(e))");
+        repr(assert, "2e^x", "Mul(2,Pow(Const(e),Var(x)))");
+        repr(assert, "cdef", "Mul(Var(c),Var(d),Const(e),Var(f))");
+        repr(assert, "pi", "Const(pi)");
+        repr(assert, "pi^2", "Pow(Const(pi),2)")
+        repr(assert, "pir", "Mul(Const(pi),Var(r))");
+        repr(assert, "pir^2", "Mul(Const(pi),Pow(Var(r),2))");
+        repr(assert, "y=x^2", "Eq(Var(y),=,Pow(Var(x),2))");
+        repr(assert, "log_2x", "Log(2,Var(x))");
+        repr(assert, "f(x+y)", "Mul(Var(f),Add(Var(x),Var(y)))");
+        repr(assert, "f(x+y)", "Func(f,Add(Var(x),Var(y)))", {functions: ["f"]});
+        repr(assert, "sin(theta)", "Trig(sin,Var(theta))");
+        repr(assert, "tanh(theta)", "Trig(tanh,Var(theta))");
 
         // verify that negative signs get folded into numbers
-        repr("-x*3", "Mul(Var(x),-3)");
-        repr("sin -x*3", "Trig(sin,Mul(Var(x),-3))");
+        repr(assert, "-x*3", "Mul(Var(x),-3)");
+        repr(assert, "sin -x*3", "Trig(sin,Mul(Var(x),-3))");
     });
 
 
     QUnit.module("rendering");
 
-    var tex = function(input, expected, options) {
+    var tex = function(assert, input, expected, options) {
         var message = input + " renders as " + expected;
-        strictEqual(parse(input, options).tex(), expected, message);
+        assert.strictEqual(parse(input, options).tex(), expected, message);
     };
 
-    test("positive and negative primitives", function() {
-        tex("0", "0");
-        tex("-1", "-1");
-        tex("--1", "--1");
-        tex("-2", "-2");
-        tex("--2", "--2");
-        tex("x", "x");
-        tex("theta", "\\theta");
-        tex("1/2", "\\frac{1}{2}");
-        tex("-1/2", "-\\frac{1}{2}");
-        tex("1/-2", "-\\frac{1}{2}");
-        tex("-1/-2", "--\\frac{1}{2}");
+    QUnit.test("positive and negative primitives", function(assert) {
+        tex(assert, "0", "0");
+        tex(assert, "-1", "-1");
+        tex(assert, "--1", "--1");
+        tex(assert, "-2", "-2");
+        tex(assert, "--2", "--2");
+        tex(assert, "x", "x");
+        tex(assert, "theta", "\\theta");
+        tex(assert, "1/2", "\\frac{1}{2}");
+        tex(assert, "-1/2", "-\\frac{1}{2}");
+        tex(assert, "1/-2", "-\\frac{1}{2}");
+        tex(assert, "-1/-2", "--\\frac{1}{2}");
     });
 
-    test("addition", function() {
-        tex("1-2", "1-2");
-        tex("a+b", "a+b");
-        tex("a-b", "a-b");
-        tex("a-1b", "a-1b");
-        tex("a+-b", "a+-b");
-        tex("a+-1b", "a+-1b");
+    QUnit.test("addition", function(assert) {
+        tex(assert, "1-2", "1-2");
+        tex(assert, "a+b", "a+b");
+        tex(assert, "a-b", "a-b");
+        tex(assert, "a-1b", "a-1b");
+        tex(assert, "a+-b", "a+-b");
+        tex(assert, "a+-1b", "a+-1b");
     });
 
-    test("multiplication", function() {
-        tex("ab", "ab");
-        tex("a*b", "ab");
-        tex("a/b", "\\frac{a}{b}");
-        tex("a/bc/d", "\\frac{ac}{bd}");
+    QUnit.test("multiplication", function(assert) {
+        tex(assert, "ab", "ab");
+        tex(assert, "a*b", "ab");
+        tex(assert, "a/b", "\\frac{a}{b}");
+        tex(assert, "a/bc/d", "\\frac{ac}{bd}");
 
-        tex("1/(x+y)", "\\frac{1}{x+y}");
-        tex("2/(x+y)", "\\frac{2}{x+y}");
-        tex("(z+2)/(x+y)", "\\frac{z+2}{x+y}");
-        tex("(z+2)/4", "\\frac{z+2}{4}");
+        tex(assert, "1/(x+y)", "\\frac{1}{x+y}");
+        tex(assert, "2/(x+y)", "\\frac{2}{x+y}");
+        tex(assert, "(z+2)/(x+y)", "\\frac{z+2}{x+y}");
+        tex(assert, "(z+2)/4", "\\frac{z+2}{4}");
     });
 
-    test("rational expressions", function() {
-        tex("x+1/2", "x+\\frac{1}{2}");
-        tex("x-1/2", "x-\\frac{1}{2}");
+    QUnit.test("rational expressions", function(assert) {
+        tex(assert, "x+1/2", "x+\\frac{1}{2}");
+        tex(assert, "x-1/2", "x-\\frac{1}{2}");
 
-        tex("1/2x", "\\frac{1}{2}x");
-        tex("1/2x/y", "\\frac{1}{2}\\frac{x}{y}");
-        tex("5*1/2x/y", "\\frac{1}{2}\\frac{5x}{y}");
-        tex("1/2*4*x/y", "\\frac{1}{2}\\frac{4x}{y}");
-        tex("-1/2x", "-\\frac{1}{2}x");
-        tex("a-1/2x", "a-\\frac{1}{2}x");
+        tex(assert, "1/2x", "\\frac{1}{2}x");
+        tex(assert, "1/2x/y", "\\frac{1}{2}\\frac{x}{y}");
+        tex(assert, "5*1/2x/y", "\\frac{1}{2}\\frac{5x}{y}");
+        tex(assert, "1/2*4*x/y", "\\frac{1}{2}\\frac{4x}{y}");
+        tex(assert, "-1/2x", "-\\frac{1}{2}x");
+        tex(assert, "a-1/2x", "a-\\frac{1}{2}x");
 
-        tex("1/(2x)", "\\frac{1}{2x}");
-        tex("8/(7p^4)", "\\frac{8}{7p^{4}}");
+        tex(assert, "1/(2x)", "\\frac{1}{2x}");
+        tex(assert, "8/(7p^4)", "\\frac{8}{7p^{4}}");
 
-        tex("x/2", "\\frac{x}{2}");
-        tex("1x/2", "\\frac{1x}{2}");
-        tex("-x/2", "-\\frac{x}{2}");
-        tex("x/-2", "-\\frac{x}{2}");
-        tex("x/-2/-3", "--\\frac{x}{2 \\cdot 3}");
-        tex("--x/2/3", "--\\frac{x}{2 \\cdot 3}");
-        tex("a-x/2", "a-\\frac{x}{2}");
+        tex(assert, "x/2", "\\frac{x}{2}");
+        tex(assert, "1x/2", "\\frac{1x}{2}");
+        tex(assert, "-x/2", "-\\frac{x}{2}");
+        tex(assert, "x/-2", "-\\frac{x}{2}");
+        tex(assert, "x/-2/-3", "--\\frac{x}{2 \\cdot 3}");
+        tex(assert, "--x/2/3", "--\\frac{x}{2 \\cdot 3}");
+        tex(assert, "a-x/2", "a-\\frac{x}{2}");
 
-        tex("1*-2", "1 \\cdot -2");
-        tex("1*-2*3", "1 \\cdot -2 \\cdot 3");
-        tex("1*-2*3/4", "1 \\cdot -2 \\cdot \\frac{3}{4}");
-        tex("1*-2*3/4/5", "1 \\cdot -2 \\cdot \\frac{3}{4} \\cdot \\frac{1}{5}");
-        tex("1/2*1/2", "\\frac{1}{2} \\cdot \\frac{1}{2}");
+        tex(assert, "1*-2", "1 \\cdot -2");
+        tex(assert, "1*-2*3", "1 \\cdot -2 \\cdot 3");
+        tex(assert, "1*-2*3/4", "1 \\cdot -2 \\cdot \\frac{3}{4}");
+        tex(assert, "1*-2*3/4/5", "1 \\cdot -2 \\cdot \\frac{3}{4} \\cdot \\frac{1}{5}");
+        tex(assert, "1/2*1/2", "\\frac{1}{2} \\cdot \\frac{1}{2}");
     });
 
-    test("exponentiation", function() {
-        tex("x^y", "x^{y}");
-        tex("xy^z", "xy^{z}");
-        tex("(xy)^z", "(xy)^{z}");
-        tex("(x+y)^z", "(x+y)^{z}");
-        tex("x^(yz)", "x^{yz}");
-        tex("x^-(yz)", "x^{-yz}");
-        tex("x^(y+z)", "x^{y+z}");
-        tex("x^-(y+z)", "x^{-(y+z)}");
-        tex("(x^y)^z", "(x^{y})^{z}");
-        tex("pir^2", "\\pi r^{2}");
+    QUnit.test("exponentiation", function(assert) {
+        tex(assert, "x^y", "x^{y}");
+        tex(assert, "xy^z", "xy^{z}");
+        tex(assert, "(xy)^z", "(xy)^{z}");
+        tex(assert, "(x+y)^z", "(x+y)^{z}");
+        tex(assert, "x^(yz)", "x^{yz}");
+        tex(assert, "x^-(yz)", "x^{-yz}");
+        tex(assert, "x^(y+z)", "x^{y+z}");
+        tex(assert, "x^-(y+z)", "x^{-(y+z)}");
+        tex(assert, "(x^y)^z", "(x^{y})^{z}");
+        tex(assert, "pir^2", "\\pi r^{2}");
     });
 
-    test("square root", function() {
-        tex("sqrt(x)", "\\sqrt{x}");
-        tex("sqrt(x)y", "\\sqrt{x}y");
-        tex("1/sqrt(x)", "\\frac{1}{\\sqrt{x}}");
-        tex("1/sqrt(x)y", "\\frac{y}{\\sqrt{x}}");
+    QUnit.test("square root", function(assert) {
+        tex(assert, "sqrt(x)", "\\sqrt{x}");
+        tex(assert, "sqrt(x)y", "\\sqrt{x}y");
+        tex(assert, "1/sqrt(x)", "\\frac{1}{\\sqrt{x}}");
+        tex(assert, "1/sqrt(x)y", "\\frac{y}{\\sqrt{x}}");
 
-        tex("sqrt(2)/2", "\\frac{\\sqrt{2}}{2}");
-        tex("sqrt(2)^2", "(\\sqrt{2})^{2}");
+        tex(assert, "sqrt(2)/2", "\\frac{\\sqrt{2}}{2}");
+        tex(assert, "sqrt(2)^2", "(\\sqrt{2})^{2}");
     });
 
-    test("nth root", function() {
+    QUnit.test("nth root", function(assert) {
         // This is an unfortunate case, but only nth degree roots with integer
         // n's get nicely printed as tex.
-        tex("sqrt[z]{x}", "x^{\\frac{1}{z}}");
+        tex(assert, "sqrt[z]{x}", "x^{\\frac{1}{z}}");
 
-        tex("sqrt[3]{x}", "\\sqrt[3]{x}");
-        tex("sqrt[3]{x}z", "\\sqrt[3]{x}z");
-        tex("1/sqrt[4]{x}", "\\frac{1}{\\sqrt[4]{x}}");
-        tex("1/sqrt[4]{x}y", "\\frac{y}{\\sqrt[4]{x}}");
+        tex(assert, "sqrt[3]{x}", "\\sqrt[3]{x}");
+        tex(assert, "sqrt[3]{x}z", "\\sqrt[3]{x}z");
+        tex(assert, "1/sqrt[4]{x}", "\\frac{1}{\\sqrt[4]{x}}");
+        tex(assert, "1/sqrt[4]{x}y", "\\frac{y}{\\sqrt[4]{x}}");
 
-        tex("sqrt[9]{2}/2", "\\frac{\\sqrt[9]{2}}{2}");
-        tex("sqrt[9]{2}^2", "(\\sqrt[9]{2})^{2}");
+        tex(assert, "sqrt[9]{2}/2", "\\frac{\\sqrt[9]{2}}{2}");
+        tex(assert, "sqrt[9]{2}^2", "(\\sqrt[9]{2})^{2}");
     });
 
-    test("absolute value", function() {
-        tex("|x|", "\\left|x\\right|");
-        tex("|x|y", "\\left|x\\right|y");
+    QUnit.test("absolute value", function(assert) {
+        tex(assert, "|x|", "\\left|x\\right|");
+        tex(assert, "|x|y", "\\left|x\\right|y");
     })
 
-    test("logarithms", function() {
-        tex("lnx", "\\ln(x)");
-        tex("logx", "\\log_{10}(x)");
-        tex("lnx^y", "\\ln(x^{y})");
-        tex("logx^y", "\\log_{10}(x^{y})");
-        tex("(lnx)^y", "[\\ln(x)]^{y}");
-        tex("(logx)^y", "[\\log_{10}(x)]^{y}");
+    QUnit.test("logarithms", function(assert) {
+        tex(assert, "lnx", "\\ln(x)");
+        tex(assert, "logx", "\\log_{10}(x)");
+        tex(assert, "lnx^y", "\\ln(x^{y})");
+        tex(assert, "logx^y", "\\log_{10}(x^{y})");
+        tex(assert, "(lnx)^y", "[\\ln(x)]^{y}");
+        tex(assert, "(logx)^y", "[\\log_{10}(x)]^{y}");
     });
 
-    test("trig functions", function() {
-        tex("sinx", "\\sin(x)");
+    QUnit.test("trig functions", function(assert) {
+        tex(assert, "sinx", "\\sin(x)");
 
-        tex("arcsin x", "\\arcsin(x)");
-        tex("sin^-1 x", "\\arcsin(x)");
+        tex(assert, "arcsin x", "\\arcsin(x)");
+        tex(assert, "sin^-1 x", "\\arcsin(x)");
 
-        tex("(sinx)^2", "\\sin^{2}(x)");
-        tex("sin^2 x", "\\sin^{2}(x)");
+        tex(assert, "(sinx)^2", "\\sin^{2}(x)");
+        tex(assert, "sin^2 x", "\\sin^{2}(x)");
 
-        tex("1/(sinx)^2", "\\frac{1}{\\sin^{2}(x)}");
-        tex("1/sin^2x", "\\frac{1}{\\sin^{2}(x)}");
+        tex(assert, "1/(sinx)^2", "\\frac{1}{\\sin^{2}(x)}");
+        tex(assert, "1/sin^2x", "\\frac{1}{\\sin^{2}(x)}");
 
-        tex("sin^2 x + cos^2 x = 1", "\\sin^{2}(x)+\\cos^{2}(x) = 1");
+        tex(assert, "sin^2 x + cos^2 x = 1", "\\sin^{2}(x)+\\cos^{2}(x) = 1");
     });
 
-    test("hyperbolic functions", function() {
-        tex("sinhx", "\\sinh(x)");
-        tex("sinh^2 x", "\\sinh^{2}(x)");
+    QUnit.test("hyperbolic functions", function(assert) {
+        tex(assert, "sinhx", "\\sinh(x)");
+        tex(assert, "sinh^2 x", "\\sinh^{2}(x)");
     });
 
-    test("multiplication with numbers", function() {
-        tex("4*10", "4 \\cdot 10");
-        tex("10^5", "10^{5}");
-        tex("4*10^5", "4 \\cdot 10^{5}");
-        tex("10^5x", "10^{5}x");
-        tex("4*10^5x", "4 \\cdot 10^{5}x");
-        tex("x*(10+4)^5", "x(10+4)^{5}");
+    QUnit.test("multiplication with numbers", function(assert) {
+        tex(assert, "4*10", "4 \\cdot 10");
+        tex(assert, "10^5", "10^{5}");
+        tex(assert, "4*10^5", "4 \\cdot 10^{5}");
+        tex(assert, "10^5x", "10^{5}x");
+        tex(assert, "4*10^5x", "4 \\cdot 10^{5}x");
+        tex(assert, "x*(10+4)^5", "x(10+4)^{5}");
 
-        tex("-1*2", "-1 \\cdot 2");
-        tex("1*-2", "1 \\cdot -2");
-        tex("-1*-2", "-1 \\cdot -2");
-        tex("-1*2*3", "-1 \\cdot 2 \\cdot 3");
+        tex(assert, "-1*2", "-1 \\cdot 2");
+        tex(assert, "1*-2", "1 \\cdot -2");
+        tex(assert, "-1*-2", "-1 \\cdot -2");
+        tex(assert, "-1*2*3", "-1 \\cdot 2 \\cdot 3");
     });
 
-    test("inverses and division", function() {
-        tex("x^-1", "x^{-1}");
-        tex("2x^-1", "2x^{-1}");
-        tex("1/x", "\\frac{1}{x}");
-        tex("-1/x", "\\frac{-1}{x}");
-        tex("2/x", "\\frac{2}{x}");
-        tex("1/x^2", "\\frac{1}{x^{2}}");
-        tex("2/x^2", "\\frac{2}{x^{2}}");
-        tex("1/1/x", "\\frac{1}{x}");
-        tex("1/(1/x)", "\\frac{1}{\\frac{1}{x}}");
-        tex("1/x/x", "\\frac{1}{xx}");
-        tex("1/(x/x)", "\\frac{1}{\\frac{x}{x}}");
-        tex("-1/1/x", "\\frac{-1}{x}");
-        tex("-1/(1/x)", "\\frac{-1}{\\frac{1}{x}}");
-        tex("-1/x/x", "\\frac{-1}{xx}");
-        tex("-1/(x/x)", "\\frac{-1}{\\frac{x}{x}}");
+    QUnit.test("inverses and division", function(assert) {
+        tex(assert, "x^-1", "x^{-1}");
+        tex(assert, "2x^-1", "2x^{-1}");
+        tex(assert, "1/x", "\\frac{1}{x}");
+        tex(assert, "-1/x", "\\frac{-1}{x}");
+        tex(assert, "2/x", "\\frac{2}{x}");
+        tex(assert, "1/x^2", "\\frac{1}{x^{2}}");
+        tex(assert, "2/x^2", "\\frac{2}{x^{2}}");
+        tex(assert, "1/1/x", "\\frac{1}{x}");
+        tex(assert, "1/(1/x)", "\\frac{1}{\\frac{1}{x}}");
+        tex(assert, "1/x/x", "\\frac{1}{xx}");
+        tex(assert, "1/(x/x)", "\\frac{1}{\\frac{x}{x}}");
+        tex(assert, "-1/1/x", "\\frac{-1}{x}");
+        tex(assert, "-1/(1/x)", "\\frac{-1}{\\frac{1}{x}}");
+        tex(assert, "-1/x/x", "\\frac{-1}{xx}");
+        tex(assert, "-1/(x/x)", "\\frac{-1}{\\frac{x}{x}}");
     });
 
-    test("distributive property", function() {
-        tex("ab+c", "ab+c");
-        tex("ab+ac", "ab+ac");
-        tex("a(b+c)", "a(b+c)");
+    QUnit.test("distributive property", function(assert) {
+        tex(assert, "ab+c", "ab+c");
+        tex(assert, "ab+ac", "ab+ac");
+        tex(assert, "a(b+c)", "a(b+c)");
     });
 
-    test("numerical exponents", function() {
-        tex("9^4", "9^{4}");
-        tex("-9^4", "-9^{4}");
-        tex("1-9^4", "1-9^{4}");
+    QUnit.test("numerical exponents", function(assert) {
+        tex(assert, "9^4", "9^{4}");
+        tex(assert, "-9^4", "-9^{4}");
+        tex(assert, "1-9^4", "1-9^{4}");
     });
 
-    test("negating a Mul", function() {
-        tex("-3x", "-3x");
-        tex("--3x", "--3x");
-        tex("-x*3", "-3x");
-        tex("--x*3", "--3x");
+    QUnit.test("negating a Mul", function(assert) {
+        tex(assert, "-3x", "-3x");
+        tex(assert, "--3x", "--3x");
+        tex(assert, "-x*3", "-3x");
+        tex(assert, "--x*3", "--3x");
     });
 
-    test("equations", function() {
-        tex("y=x", "y = x");
-        tex("y<x", "y < x");
-        tex("y>x", "y > x");
-        tex("y<>x", "y \\ne x");
-        tex("y=/=x", "y \\ne x");
-        tex("y<=x", "y \\le x");
-        tex("y>=x", "y \\ge x");
-        print("y \\le x", "y<=x");
-        print("y \\leq x", "y<=x");
-        print("y \\ge x", "y>=x");
-        print("y \\geq x", "y>=x");
+    QUnit.test("equations", function(assert) {
+        tex(assert, "y=x", "y = x");
+        tex(assert, "y<x", "y < x");
+        tex(assert, "y>x", "y > x");
+        tex(assert, "y<>x", "y \\ne x");
+        tex(assert, "y=/=x", "y \\ne x");
+        tex(assert, "y<=x", "y \\le x");
+        tex(assert, "y>=x", "y \\ge x");
+        print(assert, "y \\le x", "y<=x");
+        print(assert, "y \\leq x", "y<=x");
+        print(assert, "y \\ge x", "y>=x");
+        print(assert, "y \\geq x", "y>=x");
     });
 
-    test("function variables", function() {
-        tex("f(x)", "fx");
-        tex("f(x)", "f(x)", {functions: ["f"]});
-        tex("f(sin x)", "f(\\sin(x))", {functions: ["f"]});
-        tex("sin f(x)", "\\sin(f(x))", {functions: ["f"]});
+    QUnit.test("function variables", function(assert) {
+        tex(assert, "f(x)", "fx");
+        tex(assert, "f(x)", "f(x)", {functions: ["f"]});
+        tex(assert, "f(sin x)", "f(\\sin(x))", {functions: ["f"]});
+        tex(assert, "sin f(x)", "\\sin(f(x))", {functions: ["f"]});
     });
 
-    var texopt = function(input, expected) {
+    var texopt = function(assert, input, expected) {
         var options = {
             display: false,
             dynamic: false,
@@ -705,78 +705,78 @@
         _.each(optlist, function(opt) { options[opt] = true; });
 
         var message = input + " renders with options as " + expected;
-        strictEqual(parse(input).asTex(options), expected, message);
+        assert.strictEqual(parse(input).asTex(options), expected, message);
     };
 
-    test("options", function() {
-        texopt("x", "x");
-        texopt("x", "\\displaystyle x", "display");
-        texopt("a(b+c(d+e))", "a(b+c(d+e))");
-        texopt("a(b+c(d+e))", "a\\left(b+c\\left(d+e\\right)\\right)", "dynamic");
-        texopt("2*2", "2 \\cdot 2");
-        texopt("2*2", "2 \\times 2", "times");
+    QUnit.test("options", function(assert) {
+        texopt(assert, "x", "x");
+        texopt(assert, "x", "\\displaystyle x", "display");
+        texopt(assert, "a(b+c(d+e))", "a(b+c(d+e))");
+        texopt(assert, "a(b+c(d+e))", "a\\left(b+c\\left(d+e\\right)\\right)", "dynamic");
+        texopt(assert, "2*2", "2 \\cdot 2");
+        texopt(assert, "2*2", "2 \\times 2", "times");
 
-        texopt("1*2(3+4)", "\\displaystyle 1 \\times 2\\left(3+4\\right)",
+        texopt(assert, "1*2(3+4)", "\\displaystyle 1 \\times 2\\left(3+4\\right)",
             "display", "dynamic", "times");
     });
 
 
     QUnit.module("evaluating");
 
-    var val = function(input, expected, vars, functions) {
+    var val = function(assert, input, expected, vars, functions) {
         if (vars === undefined) vars = {};
         var message = input + " evaluates as " + expected;
-        strictEqual(parse(input, {functions: functions}).eval(vars, {functions: functions}), expected, message);
+        assert.strictEqual(parse(input, {functions: functions}).eval(vars, {functions: functions}), expected, message);
     };
 
-    test("empty", function() {
-        val("", 0);
+    QUnit.test("empty", function(assert) {
+        val(assert, "", 0);
     });
 
-    test("simple expressions", function() {
-        val("1+2+3+4", 10);
-        val("1+2-3+4", 4);
-        val("1*2*3*4", 24);
-        val("1*2/3*4", 2 + 2/3);
-        val("4^3^2^1", 262144);
-        val("-1", -1);
-        val("--1", 1);
-        val("---1", -1);
-        val("2^-2", .25);
-        val("8^(1/3)", 2);
-        val("0^0", 1);
-        val(".25*4", 1);
-        val("ln e", 1);
-        val("log 10", 1);
-        val("log_2 2", 1);
+    QUnit.test("simple expressions", function(assert) {
+        val(assert, "1+2+3+4", 10);
+        val(assert, "1+2-3+4", 4);
+        val(assert, "1*2*3*4", 24);
+        val(assert, "1*2/3*4", 2 + 2/3);
+        val(assert, "4^3^2^1", 262144);
+        val(assert, "-1", -1);
+        val(assert, "--1", 1);
+        val(assert, "---1", -1);
+        val(assert, "2^-2", .25);
+        val(assert, "8^(1/3)", 2);
+        val(assert, "0^0", 1);
+        val(assert, ".25*4", 1);
+        val(assert, "ln e", 1);
+        val(assert, "log 10", 1);
+        val(assert, "log_2 2", 1);
     });
 
-    test("hyperbolic expressions", function() {
-        val("cosh(0.2)", 1.0200667556190757);
-        val("coth(0.2)", 5.06648956343947);
-        val("csch(3 * 2)", 0.004957534813479361);
+    QUnit.test("hyperbolic expressions", function(assert) {
+        val(assert, "cosh(0.2)", 1.020066755619076);
+        val(assert, "coth(0.2)", 5.066489563439473);
+        val(assert, "csch(3 * 2)", 0.00495753481347936);
     });
 
-    test("variable expressions", function() {
-        val("x", 3, {x: 3});
-        val("x^2", 9, {x: 3});
-        val("(x^2+y^2)^.5", 5, {x: 3, y: 4});
-        val("log x_0", 1, {x_0: 10});
-        val("log x_0 + log x_1", 3, {x_0: 10, x_1: 100});
-        val("log x_42", 1, {x_42: 10});
-        val("x_a + x_bc", 7, {x_a: 1, x_b: 2, c: 3});
+    QUnit.test("variable expressions", function(assert) {
+        val(assert, "x", 3, {x: 3});
+        val(assert, "x^2", 9, {x: 3});
+        val(assert, "(x^2+y^2)^.5", 5, {x: 3, y: 4});
+        val(assert, "log x_0", 1, {x_0: 10});
+        val(assert, "log x_0 + log x_1", 3, {x_0: 10, x_1: 100});
+        val(assert, "log x_42", 1, {x_42: 10});
+        val(assert, "x_a + x_bc", 7, {x_a: 1, x_b: 2, c: 3});
     });
 
-    test("function expressions", function() {
-        val("f(2)", 4, {"f": "2x"}, ["f"]);
-        val("f(4+8)", 48, {"f": "4x"}, ["f"]);
-        val("f(x-1)-f(x)", -7, {"f": "x^3", "x": 2}, ["f"]);
-        val("g(1)", -1, {f: "x", g: "-f(x)"}, ["f", "g"]);
+    QUnit.test("function expressions", function(assert) {
+        val(assert, "f(2)", 4, {"f": "2x"}, ["f"]);
+        val(assert, "f(4+8)", 48, {"f": "4x"}, ["f"]);
+        val(assert, "f(x-1)-f(x)", -7, {"f": "x^3", "x": 2}, ["f"]);
+        val(assert, "g(1)", -1, {f: "x", g: "-f(x)"}, ["f", "g"]);
     });
 
     QUnit.module("compilation");
 
-    var compile = function(input, expected, vars, functions) {
+    var compile = function(assert, input, expected, vars, functions) {
         if (vars === undefined) vars = {};
         var func = parse(input, {functions: functions}).compile();
         var result;
@@ -787,70 +787,70 @@
         }
         var message = input + " should evaluate to " + expected +
 			", was " + result + "; by func: " + func.toString();
-        ok(Math.abs(result - expected) < 1e-9, message);
+        assert.ok(Math.abs(result - expected) < 1e-9, message);
     };
 
-    test("empty", function() {
-        compile("", 0);
+    QUnit.test("empty", function(assert) {
+        compile(assert, "", 0);
     });
 
-    test("simple expressions", function() {
-        compile("1+2+3+4", 10);
-        compile("1+2-3+4", 4);
-        compile("1*2*3*4", 24);
-        compile("1*2/3*4", 2 + 2/3);
-        compile("4^3^2^1", 262144);
-        compile("-1", -1);
-        compile("--1", 1);
-        compile("---1", -1);
-        compile("2^-2", .25);
-        compile("8^(1/3)", 2);
-        compile("0^0", 1);
-        compile(".25*4", 1);
-        compile("ln e", 1);
-        compile("log 10", 1);
-        compile("log_2 2", 1);
+    QUnit.test("simple expressions", function(assert) {
+        compile(assert, "1+2+3+4", 10);
+        compile(assert, "1+2-3+4", 4);
+        compile(assert, "1*2*3*4", 24);
+        compile(assert, "1*2/3*4", 2 + 2/3);
+        compile(assert, "4^3^2^1", 262144);
+        compile(assert, "-1", -1);
+        compile(assert, "--1", 1);
+        compile(assert, "---1", -1);
+        compile(assert, "2^-2", .25);
+        compile(assert, "8^(1/3)", 2);
+        compile(assert, "0^0", 1);
+        compile(assert, ".25*4", 1);
+        compile(assert, "ln e", 1);
+        compile(assert, "log 10", 1);
+        compile(assert, "log_2 2", 1);
     });
 
-    test("variable expressions", function() {
-        compile("x", 3, {x: 3});
-        compile("x^2", 9, {x: 3});
-        compile("(x^2+y^2)^.5", 5, {x: 3, y: 4});
-        compile("log x_0", 1, {x_0: 10});
-        compile("log x_0 + log x_1", 3, {x_0: 10, x_1: 100});
-        compile("log x_42", 1, {x_42: 10});
-        compile("x_a + x_bc", 7, {x_a: 1, x_b: 2, c: 3});
+    QUnit.test("variable expressions", function(assert) {
+        compile(assert, "x", 3, {x: 3});
+        compile(assert, "x^2", 9, {x: 3});
+        compile(assert, "(x^2+y^2)^.5", 5, {x: 3, y: 4});
+        compile(assert, "log x_0", 1, {x_0: 10});
+        compile(assert, "log x_0 + log x_1", 3, {x_0: 10, x_1: 100});
+        compile(assert, "log x_42", 1, {x_42: 10});
+        compile(assert, "x_a + x_bc", 7, {x_a: 1, x_b: 2, c: 3});
     });
 
-    test("function expressions", function() {
-        compile("f(2)", 4, {"f": function(x) { return 2 * x; }}, ["f"]);
-        compile("f(4+8)", 48, {"f": function(x) { return 4 * x; }}, ["f"]);
-        compile("f(x-1)-f(x)", -7, {"f": function(x) { return Math.pow(x, 3); }, "x": 2}, ["f"]);
+    QUnit.test("function expressions", function(assert) {
+        compile(assert, "f(2)", 4, {"f": function(x) { return 2 * x; }}, ["f"]);
+        compile(assert, "f(4+8)", 48, {"f": function(x) { return 4 * x; }}, ["f"]);
+        compile(assert, "f(x-1)-f(x)", -7, {"f": function(x) { return Math.pow(x, 3); }, "x": 2}, ["f"]);
     });
 
-    test("trig expressions", function() {
-        compile("-2sin(pi x) + 4", 4, {x: 32});
-        compile("sin(pi x)", 0, {x: 6});
-        compile("sin(x)", 1, {x: Math.PI / 2});
-        compile("sin(pi x)", -1, {x: 3/2});
-        compile("cos(x)", 1, {x: 0});
-        compile("cos x", -1, {x: Math.PI});
-        compile("tan(x)", 0, {x: 0});
-        compile("tan x", 1, {x: Math.PI / 4});
+    QUnit.test("trig expressions", function(assert) {
+        compile(assert, "-2sin(pi x) + 4", 4, {x: 32});
+        compile(assert, "sin(pi x)", 0, {x: 6});
+        compile(assert, "sin(x)", 1, {x: Math.PI / 2});
+        compile(assert, "sin(pi x)", -1, {x: 3/2});
+        compile(assert, "cos(x)", 1, {x: 0});
+        compile(assert, "cos x", -1, {x: Math.PI});
+        compile(assert, "tan(x)", 0, {x: 0});
+        compile(assert, "tan x", 1, {x: Math.PI / 4});
     });
 
     QUnit.module("checking form");
 
-    var norm = function(input, reference) {
+    var norm = function(assert, input, reference) {
         var actual = parse(input).normalize().print();
         var expected = parse(reference).normalize().print();
         var message = input + " is the same as " + reference;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    test("normalize", function() {
-        norm("ab", "ba");
-        norm("(ab)c", "(cb)a");
+    QUnit.test("normalize", function(assert) {
+        norm(assert, "ab", "ba");
+        norm(assert, "(ab)c", "(cb)a");
 
         var forms = [
             "(6x+1)(x-1)",
@@ -864,20 +864,20 @@
         ];
 
         _.each(forms, function(form) {
-            norm(forms[0], form);
+            norm(assert, forms[0], form);
         });
     });
 
-    var stripnorm = function(input, reference) {
+    var stripnorm = function(assert, input, reference) {
         var actual = parse(input).strip().normalize().print();
         var expected = parse(reference).strip().normalize().print();
         var message = input + " is the same as " + reference;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    test("strip then normalize", function() {
-        stripnorm("ab", "ba");
-        stripnorm("(ab)c", "(cb)a");
+    QUnit.test("strip then normalize", function(assert) {
+        stripnorm(assert, "ab", "ba");
+        stripnorm(assert, "(ab)c", "(cb)a");
 
         var forms = [
             "(6x+1)(x-1)",
@@ -901,21 +901,21 @@
         ];
 
         _.each(forms, function(form) {
-            stripnorm(forms[0], form);
+            stripnorm(assert, forms[0], form);
         });
     })
 
 
     QUnit.module("equation to expression");
 
-    var asExpr = function(input, reference) {
+    var asExpr = function(assert, input, reference) {
         var actual = parse(input).asExpr().simplify().normalize().print();
         var expected = parse(reference).normalize().print();
         var message = input + " as an expression is " + reference;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    test("", function() {
+    QUnit.test("", function(assert) {
         var forms = [
             "y=2x-5",
             "-2x+5=-y",
@@ -932,9 +932,9 @@
 
         _.each(forms, function(form) {
             if (form.indexOf("<>") !== -1) {
-                asExpr(form, "-y+2x-5");
+                asExpr(assert, form, "-y+2x-5");
             } else {
-                asExpr(form, "y-2x+5");
+                asExpr(assert, form, "y-2x+5");
             }
         });
 
@@ -946,24 +946,24 @@
         ];
 
         _.each(forms2, function(form) {
-            asExpr(form, "p-351");
+            asExpr(assert, form, "p-351");
         });
     });
 
 
     QUnit.module("comparing");
 
-    var compare = function(options, input, reference, expectedResult) {
+    var compare = function(assert, options, input, reference, expectedResult) {
         var actual = parse(input, {functions: ["f", "g", "h"]});
         var expected = parse(reference, {functions: ["f", "g", "h"]});
         var result = KAS.compare(actual, expected, options);
         if (expectedResult === undefined) expectedResult = true;
         var message = input + " is " + (expectedResult ? "" : "NOT ") + "the same as " + reference;
-        ok(result.equal === expectedResult, message);
+        assert.equal(result.equal, expectedResult, message);
     };
 
-    test("evaluate only", function() {
-        var comp = _.partial(compare, {form: false});
+    QUnit.test("evaluate only", function(assert) {
+        var comp = _.partial(compare, assert, {form: false});
 
         comp("2+2", "4");
         comp("a(b+c)", "ab+ac");
@@ -1161,8 +1161,8 @@
         comp("(-2)^(n+0.1)", "(-2)^(n+1.1)");
     });
 
-    test("simplify can't yet handle these", function() {
-        var comp = _.partial(compare, {form: false});
+    QUnit.test("simplify can't yet handle these", function(assert) {
+        var comp = _.partial(compare, assert, {form: false});
 
         comp("sin(x + 2pi)", "sin(x)");
         comp("y = sin(x + 2pi)", "y = sin(x)");
@@ -1170,8 +1170,8 @@
         comp("y = sin^2(x)+cos^2(x)", "y = x/x");
     });
 
-    test("partially evaluating functions", function() {
-        var comp = _.partial(compare, {form: false});
+    QUnit.test("partially evaluating functions", function(assert) {
+        var comp = _.partial(compare, assert, {form: false});
 
         comp("f(x)", "f(x)");
         comp("f(x)", "g(x)", false);
@@ -1182,8 +1182,8 @@
         comp("f(x) = ln|x|+c", "f(x)-ln|x|-c = 0");
     });
 
-    test("evaluating and comparing form", function() {
-        var comp = _.partial(compare, {form: true});
+    QUnit.test("evaluating and comparing form", function(assert) {
+        var comp = _.partial(compare, assert, {form: false});
 
         comp("ab", "ba");
         comp("(ab)c", "(cb)a");
@@ -1231,359 +1231,359 @@
 
     QUnit.module("findGCD");
 
-    var findGCD = function(a, b, reference) {
+    var findGCD = function(assert, a, b, reference) {
         var actual = parse(a).findGCD(parse(b)).repr();
         var expected = parse(reference).repr();
 
         var message = "(" + a + ").findGCD(" + b + ") = " + expected;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    test("findGCD on ints", function() {
-        findGCD("40", "30", "10");
-        findGCD("14", "21", "7");
-        findGCD("13", "26", "13");
+    QUnit.test("findGCD on ints", function(assert) {
+        findGCD(assert, "40", "30", "10");
+        findGCD(assert, "14", "21", "7");
+        findGCD(assert, "13", "26", "13");
     });
 
-    test("findGCD on rationals", function() {
-        findGCD("40/3", "55/6", "5/6");
-        findGCD("3/4", "1/2", "1/4");
-        findGCD("3/7", "12/22", "3/77");
-        findGCD("3/10", "4/15", "1/30");
-        findGCD("2/3", "23/6", "1/6");
-        findGCD("2/3", "22/6", "1/3");
+    QUnit.test("findGCD on rationals", function(assert) {
+        findGCD(assert, "40/3", "55/6", "5/6");
+        findGCD(assert, "3/4", "1/2", "1/4");
+        findGCD(assert, "3/7", "12/22", "3/77");
+        findGCD(assert, "3/10", "4/15", "1/30");
+        findGCD(assert, "2/3", "23/6", "1/6");
+        findGCD(assert, "2/3", "22/6", "1/3");
 
-        findGCD("2/3", "2", "2/3");
-        findGCD("2/3", "3", "1/3");
-        findGCD("1/2", "4", "1/2");
-        findGCD("4", "3/4", "1/4");
-        findGCD("3", "3/4", "3/4");
+        findGCD(assert, "2/3", "2", "2/3");
+        findGCD(assert, "2/3", "3", "1/3");
+        findGCD(assert, "1/2", "4", "1/2");
+        findGCD(assert, "4", "3/4", "1/4");
+        findGCD(assert, "3", "3/4", "3/4");
     });
 
-    test("findGCD on floats", function() {
+    QUnit.test("findGCD on floats", function(assert) {
         // Feel free to change this when we do something other
         // than a naive "return 1" for floats
-        findGCD("1.23", "1.42", "1");
-        findGCD("1", String(Math.PI), "1");
+        findGCD(assert, "1.23", "1.42", "1");
+        findGCD(assert, "1", String(Math.PI), "1");
     });
 
     QUnit.module("transforming");
 
-    var factor = function(input, reference) {
+    var factor = function(assert, input, reference) {
         var actual = parse(input).factor().normalize().repr();
         var expected = parse(reference).normalize().repr();
         var message = input + " factors as " + reference;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    test("factoring Adds", function() {
-        factor("2+2", "2(1+1)");
-        factor("-2-2", "-2(1+1)");
-        factor("2x+2", "2(x+1)");
-        factor("x^3+x^2", "x^2(x+1)");
-        factor("2x+xy", "x(2+y)");
-        factor("2xy+xy^2", "xy(2+y)");
-        factor("2+2/3", "2/3(3+1)");  // a little questionable, but 2/3 is what
+    QUnit.test("factoring Adds", function(assert) {
+        factor(assert, "2+2", "2(1+1)");
+        factor(assert, "-2-2", "-2(1+1)");
+        factor(assert, "2x+2", "2(x+1)");
+        factor(assert, "x^3+x^2", "x^2(x+1)");
+        factor(assert, "2x+xy", "x(2+y)");
+        factor(assert, "2xy+xy^2", "xy(2+y)");
+        factor(assert, "2+2/3", "2/3(3+1)");  // a little questionable, but 2/3 is what
                                       // wolframalpha returns for the gcd, so
                                       // we pull it out
-        factor("2x+1.1", "2x+1.1");
+        factor(assert, "2x+1.1", "2x+1.1");
     });
 
-    test("factoring Muls", function() {
-        factor("(2x+2)/(x+1)", "2 (x+1)/(x+1)");
-        factor("(x+1)/(2x+2)", "1/2 (x+1)/(x+1)");
+    QUnit.test("factoring Muls", function(assert) {
+        factor(assert, "(2x+2)/(x+1)", "2 (x+1)/(x+1)");
+        factor(assert, "(x+1)/(2x+2)", "1/2 (x+1)/(x+1)");
     });
 
-    test("factoring Pows", function() {
-        factor("x^y+x^(2y)", "x^y(1+x^y)");
-        factor("x^y+x^z", "x^y+x^z");
+    QUnit.test("factoring Pows", function(assert) {
+        factor(assert, "x^y+x^(2y)", "x^y(1+x^y)");
+        factor(assert, "x^y+x^z", "x^y+x^z");
     });
 
-    var expand = function(input, reference) {
+    var expand = function(assert, input, reference) {
         var actual = parse(input).expand().normalize().print();
         var expected = parse(reference).normalize().print();
         var message = input + " expands as " + reference;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    var expandrepr = function(input, expected) {
+    var expandrepr = function(assert, input, expected) {
         var actual = parse(input).expand().repr();
         var message = input + " expands as " + expected;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    var expandtex = function(input, expected) {
+    var expandtex = function(assert, input, expected) {
         var actual = parse(input).expand().tex();
         var message = input + " expands and is rendered as " + expected;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    test("distribute over multiplication", function() {
-        expand("a(b+c)", "ab+ac");
-        expandtex("a(b+c)", "ab+ac");
-        expandrepr("a(b+c)", "Add(Mul(Var(a),Var(b)),Mul(Var(a),Var(c)))");
+    QUnit.test("distribute over multiplication", function(assert) {
+        expand(assert, "a(b+c)", "ab+ac");
+        expandtex(assert, "a(b+c)", "ab+ac");
+        expandrepr(assert, "a(b+c)", "Add(Mul(Var(a),Var(b)),Mul(Var(a),Var(c)))");
 
-        expand("a(b-c)", "ab-ac");
-        expandtex("a(b-c)", "ab-ac");
-        expandrepr("a(b-c)", "Add(Mul(Var(a),Var(b)),Mul(Var(a),-1,Var(c)))");
+        expand(assert, "a(b-c)", "ab-ac");
+        expandtex(assert, "a(b-c)", "ab-ac");
+        expandrepr(assert, "a(b-c)", "Add(Mul(Var(a),Var(b)),Mul(Var(a),-1,Var(c)))");
 
-        expand("a(b+c)d", "abd+acd");
-        expandrepr("a(b+c)d", "Add(Mul(Var(a),Var(d),Var(b)),Mul(Var(a),Var(d),Var(c)))");
+        expand(assert, "a(b+c)d", "abd+acd");
+        expandrepr(assert, "a(b+c)d", "Add(Mul(Var(a),Var(d),Var(b)),Mul(Var(a),Var(d),Var(c)))");
 
-        expand("(a+b)(c+d)", "ac+ad+bc+bd");
-        expand("(a+b)(c+d)ef", "acef+adef+bcef+bdef");
-        expand("(a+b)c^d", "ac^d+bc^d");
-        expand("ab(c+d)e^f", "abce^f+abde^f");
+        expand(assert, "(a+b)(c+d)", "ac+ad+bc+bd");
+        expand(assert, "(a+b)(c+d)ef", "acef+adef+bcef+bdef");
+        expand(assert, "(a+b)c^d", "ac^d+bc^d");
+        expand(assert, "ab(c+d)e^f", "abce^f+abde^f");
 
-        expand("(a+b(c+d))e", "ae+bce+bde");
-        expandrepr("(a+b(c+d))e", "Add(Mul(Const(e),Var(a)),Mul(Const(e),Var(b),Var(c)),Mul(Const(e),Var(b),Var(d)))");
+        expand(assert, "(a+b(c+d))e", "ae+bce+bde");
+        expandrepr(assert, "(a+b(c+d))e", "Add(Mul(Const(e),Var(a)),Mul(Const(e),Var(b),Var(c)),Mul(Const(e),Var(b),Var(d)))");
     });
 
-    test("distribute over rational expressions", function() {
-        expand("(a+b)/(c+d)", "(a+b)/(c+d)");
-        expand("(a+b)/(c+d)*a", "(aa+ab)/(c+d)");
-        expand("(a+b)/(c+d)*1/e", "(a+b)/(ce+de)");
-        expand("(a+b)/(c+d)*a/e", "(aa+ab)/(ce+de)");
+    QUnit.test("distribute over rational expressions", function(assert) {
+        expand(assert, "(a+b)/(c+d)", "(a+b)/(c+d)");
+        expand(assert, "(a+b)/(c+d)*a", "(aa+ab)/(c+d)");
+        expand(assert, "(a+b)/(c+d)*1/e", "(a+b)/(ce+de)");
+        expand(assert, "(a+b)/(c+d)*a/e", "(aa+ab)/(ce+de)");
     });
 
-    test("expand exponentiation", function() {
-        expand("(ab)^2", "a^2 b^2");
-        expand("2*(ab)^2", "2 a^2 b^2");
-        expand("(a+b)^2", "a^2+2ab+b^2");
+    QUnit.test("expand exponentiation", function(assert) {
+        expand(assert, "(ab)^2", "a^2 b^2");
+        expand(assert, "2*(ab)^2", "2 a^2 b^2");
+        expand(assert, "(a+b)^2", "a^2+2ab+b^2");
 
-        expand("(ab)^-2", "a^-2 b^-2");
-        expand("2*(ab)^-2", "2 a^-2 b^-2");
-        expand("(a+b)^-2", "(a^2+2ab+b^2)^-1");
+        expand(assert, "(ab)^-2", "a^-2 b^-2");
+        expand(assert, "2*(ab)^-2", "2 a^-2 b^-2");
+        expand(assert, "(a+b)^-2", "(a^2+2ab+b^2)^-1");
     });
 
-    test("expand absolute value", function() {
-        expand("|a+b|", "|a+b|");
-        expand("|ab|", "|a|*|b|");
+    QUnit.test("expand absolute value", function(assert) {
+        expand(assert, "|a+b|", "|a+b|");
+        expand(assert, "|ab|", "|a|*|b|");
     });
 
-    test("expand logarithms", function() {
-        expand("ln(xy)", "lnx+lny");
-        expand("log_b(x)", "lnx/lnb");
-        expand("log_b(xy)", "lnx/lnb+lny/lnb");
-        expand("ln(xy/z)", "lnx+lny-lnz");
+    QUnit.test("expand logarithms", function(assert) {
+        expand(assert, "ln(xy)", "lnx+lny");
+        expand(assert, "log_b(x)", "lnx/lnb");
+        expand(assert, "log_b(xy)", "lnx/lnb+lny/lnb");
+        expand(assert, "ln(xy/z)", "lnx+lny-lnz");
 
-        expand("ln(x^y)", "ylnx");
-        expand("log_b(x^y)", "ylnx/lnb");
-        expand("ln(x^y^z)", "y^zlnx");
+        expand(assert, "ln(x^y)", "ylnx");
+        expand(assert, "log_b(x^y)", "ylnx/lnb");
+        expand(assert, "ln(x^y^z)", "y^zlnx");
 
-        expand("ln(x^y/z)", "ylnx-lnz");
+        expand(assert, "ln(x^y/z)", "ylnx-lnz");
 
         // ln((xy)^z) -> ln(x^z*y^z) -> z*ln(x)+z*ln(y)
-        expand("ln((xy)^z)", "zlnx+zlny");
+        expand(assert, "ln((xy)^z)", "zlnx+zlny");
 
-        expand("log_b(x)log_x(y)", "ln(x)/ln(b)*ln(y)/ln(x)");
-        expand("log_b(x)log_x(y)log_y(z)", "ln(x)/ln(b)*ln(y)/ln(x)*ln(z)/ln(y)");
+        expand(assert, "log_b(x)log_x(y)", "ln(x)/ln(b)*ln(y)/ln(x)");
+        expand(assert, "log_b(x)log_x(y)log_y(z)", "ln(x)/ln(b)*ln(y)/ln(x)*ln(z)/ln(y)");
     });
 
-    test("expand trig functions", function() {
-        expand("sin(x)", "sin(x)");
-        expand("cos(x)", "cos(x)");
-        expand("tan(x)", "sin(x)/cos(x)");
-        expand("csc(x)", "1/sin(x)");
-        expand("sec(x)", "1/cos(x)");
-        expand("cot(x)", "cos(x)/sin(x)");
+    QUnit.test("expand trig functions", function(assert) {
+        expand(assert, "sin(x)", "sin(x)");
+        expand(assert, "cos(x)", "cos(x)");
+        expand(assert, "tan(x)", "sin(x)/cos(x)");
+        expand(assert, "csc(x)", "1/sin(x)");
+        expand(assert, "sec(x)", "1/cos(x)");
+        expand(assert, "cot(x)", "cos(x)/sin(x)");
     });
 
-    test("expand hyperbolic functions", function() {
-        expand("sinh(x)", "sinh(x)");
-        expand("cosh(x)", "cosh(x)");
-        expand("tanh(x)", "sinh(x)/cosh(x)");
-        expand("csch(x)", "1/sinh(x)");
-        expand("sech(x)", "1/cosh(x)");
-        expand("coth(x)", "cosh(x)/sinh(x)");
+    QUnit.test("expand hyperbolic functions", function(assert) {
+        expand(assert, "sinh(x)", "sinh(x)");
+        expand(assert, "cosh(x)", "cosh(x)");
+        expand(assert, "tanh(x)", "sinh(x)/cosh(x)");
+        expand(assert, "csch(x)", "1/sinh(x)");
+        expand(assert, "sech(x)", "1/cosh(x)");
+        expand(assert, "coth(x)", "cosh(x)/sinh(x)");
     });
 
-    var collect = function(input, reference) {
+    var collect = function(assert, input, reference) {
         var actual = parse(input).collect().normalize().print();
         var expected = parse(reference).normalize().print();
         var message = input + " collects as " + reference;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    var collectrepr = function(input, expected) {
+    var collectrepr = function(assert, input, expected) {
         var actual = parse(input).collect().repr();
         var message = input + " collects as " + expected;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    var collecttex = function(input, expected) {
+    var collecttex = function(assert, input, expected) {
         var actual = parse(input).collect().tex();
         var message = input + " collects and is rendered as " + expected;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    test("collect over addition", function() {
-        collect("", "0");
-        collect("0", "0");
-        collect("1+3", "4");
-        collect("x+3", "3+x");
-        collect("x+3x", "4x");
-        collectrepr("x+3x", "Mul(4,Var(x))");
-        collect("a+a+a", "3a");
-        collectrepr("a+a+a", "Mul(3,Var(a))");
-        collect("a+b+b+c", "a+2b+c");
-        collectrepr("a+b+b+c", "Add(Var(a),Mul(2,Var(b)),Var(c))");
-        collect("4x^2-x^2+8x+7-5x-4", "3+3x+3x^2");
+    QUnit.test("collect over addition", function(assert) {
+        collect(assert, "", "0");
+        collect(assert, "0", "0");
+        collect(assert, "1+3", "4");
+        collect(assert, "x+3", "3+x");
+        collect(assert, "x+3x", "4x");
+        collectrepr(assert, "x+3x", "Mul(4,Var(x))");
+        collect(assert, "a+a+a", "3a");
+        collectrepr(assert, "a+a+a", "Mul(3,Var(a))");
+        collect(assert, "a+b+b+c", "a+2b+c");
+        collectrepr(assert, "a+b+b+c", "Add(Var(a),Mul(2,Var(b)),Var(c))");
+        collect(assert, "4x^2-x^2+8x+7-5x-4", "3+3x+3x^2");
     });
 
-    test("collect over multiplication", function() {
-        collect("5*7", "35");
-        collect("5*7x+20x", "55x");
-        collect("3x*xy+2yx^2", "5x^2y");
-        collect("4/6", "2/3");
-        collect("1/1", "1");
-        collect("1/2+1/3", "5/6");
-        collect("1/2+1/3+1", "11/6");
-        collect("1.2+1/2", "1.7");
-        collect("1/2-1/2", "0");
-        collect("1/2-.5", "0");
+    QUnit.test("collect over multiplication", function(assert) {
+        collect(assert, "5*7", "35");
+        collect(assert, "5*7x+20x", "55x");
+        collect(assert, "3x*xy+2yx^2", "5x^2y");
+        collect(assert, "4/6", "2/3");
+        collect(assert, "1/1", "1");
+        collect(assert, "1/2+1/3", "5/6");
+        collect(assert, "1/2+1/3+1", "11/6");
+        collect(assert, "1.2+1/2", "1.7");
+        collect(assert, "1/2-1/2", "0");
+        collect(assert, "1/2-.5", "0");
     });
 
-    test("collect over exponentiation", function() {
-        collect("x^0", "1");
-        collect("x^1", "x");
-        collect("x^(log_x y)", "y");
-        collect("(x^y)^z", "x^(yz)");
-        collect("0^0", "1");
-        collect("4^1.5", "8");
-        collect("(2/3)^2", "4/9");
-        collect("(2/3)^-2", "9/4");
+    QUnit.test("collect over exponentiation", function(assert) {
+        collect(assert, "x^0", "1");
+        collect(assert, "x^1", "x");
+        collect(assert, "x^(log_x y)", "y");
+        collect(assert, "(x^y)^z", "x^(yz)");
+        collect(assert, "0^0", "1");
+        collect(assert, "4^1.5", "8");
+        collect(assert, "(2/3)^2", "4/9");
+        collect(assert, "(2/3)^-2", "9/4");
     });
 
-    test("collect over roots", function() {
-        collect("sqrt(2)^2", "2");
-        collect("sqrt[3]{3}^3", "3");
-        collect("(2^(1/3))^3", "2");
+    QUnit.test("collect over roots", function(assert) {
+        collect(assert, "sqrt(2)^2", "2");
+        collect(assert, "sqrt[3]{3}^3", "3");
+        collect(assert, "(2^(1/3))^3", "2");
     });
 
-    test("collect over absolute value", function() {
-        collect("|x|", "|x|");
-        collect("|2|", "2");
-        collect("|0|", "0");
-        collect("|-2|", "2");
-        collect("|pi|", "pi");
-        collect("|2^x|", "2^x");
-        collect("|x^2|", "x^2");
-        collect("|-2pix^2y^3|", "2pix^2*|y^3|");
+    QUnit.test("collect over absolute value", function(assert) {
+        collect(assert, "|x|", "|x|");
+        collect(assert, "|2|", "2");
+        collect(assert, "|0|", "0");
+        collect(assert, "|-2|", "2");
+        collect(assert, "|pi|", "pi");
+        collect(assert, "|2^x|", "2^x");
+        collect(assert, "|x^2|", "x^2");
+        collect(assert, "|-2pix^2y^3|", "2pix^2*|y^3|");
     });
 
-    test("collect over logarithms", function() {
-        collect("log(1)", "0");
-        collect("log_x(x)", "1");
-        collect("log_b(b^x)", "x");
+    QUnit.test("collect over logarithms", function(assert) {
+        collect(assert, "log(1)", "0");
+        collect(assert, "log_x(x)", "1");
+        collect(assert, "log_b(b^x)", "x");
 
-        collect("b^(2*y*log_b x)", "x^(2y)");
-        collect("b^(log_b a) b^(-log_b c)", "a/c");
+        collect(assert, "b^(2*y*log_b x)", "x^(2y)");
+        collect(assert, "b^(log_b a) b^(-log_b c)", "a/c");
 
-        collect("ln(x)/ln(b)", "log_b(x)");
-        collect("ln(x)/ln(b)*ln(y)/ln(x)", "log_b(y)");
-        collect("ln(x)/ln(b)*ln(y)/ln(x)*ln(z)/ln(y)", "log_b(z)");
+        collect(assert, "ln(x)/ln(b)", "log_b(x)");
+        collect(assert, "ln(x)/ln(b)*ln(y)/ln(x)", "log_b(y)");
+        collect(assert, "ln(x)/ln(b)*ln(y)/ln(x)*ln(z)/ln(y)", "log_b(z)");
     });
 
-    test("collect trig functions", function() {
-        collect("sin(x)cos(x)", "sin(x)cos(x)");
-        collect("sin(x)/cos(x)", "tan(x)");
+    QUnit.test("collect trig functions", function(assert) {
+        collect(assert, "sin(x)cos(x)", "sin(x)cos(x)");
+        collect(assert, "sin(x)/cos(x)", "tan(x)");
 
-        collect("sin^2(x)/cos^2(x)", "tan^2(x)");
-        collect("cos^2(x)/sin^2(x)", "cot^2(x)");
+        collect(assert, "sin^2(x)/cos^2(x)", "tan^2(x)");
+        collect(assert, "cos^2(x)/sin^2(x)", "cot^2(x)");
 
-        collect("sin^-2(x)/cos^-2(x)", "cot^2(x)");
-        collect("cos^-2(x)/sin^-2(x)", "tan^2(x)");
+        collect(assert, "sin^-2(x)/cos^-2(x)", "cot^2(x)");
+        collect(assert, "cos^-2(x)/sin^-2(x)", "tan^2(x)");
 
-        collect("sin^--2(x)/cos^--2(x)", "tan^2(x)");
-        collect("cos^--2(x)/sin^--2(x)", "cot^2(x)");
+        collect(assert, "sin^--2(x)/cos^--2(x)", "tan^2(x)");
+        collect(assert, "cos^--2(x)/sin^--2(x)", "cot^2(x)");
 
-        collect("sin^2(x)/cos(x)", "sin^2(x)/cos(x)");
-        collect("sin(x)/cos^2(x)", "sin(x)/cos^2(x)");
+        collect(assert, "sin^2(x)/cos(x)", "sin^2(x)/cos(x)");
+        collect(assert, "sin(x)/cos^2(x)", "sin(x)/cos^2(x)");
 
-        collect("sin(-x)", "-sin(x)");
-        collect("cos(-x)", "cos(x)");
-        collect("tan(-x)", "-tan(x)");
-        collect("csc(-x)", "-csc(x)");
-        collect("sec(-x)", "sec(x)");
-        collect("cot(-x)", "-cot(x)");
+        collect(assert, "sin(-x)", "-sin(x)");
+        collect(assert, "cos(-x)", "cos(x)");
+        collect(assert, "tan(-x)", "-tan(x)");
+        collect(assert, "csc(-x)", "-csc(x)");
+        collect(assert, "sec(-x)", "sec(x)");
+        collect(assert, "cot(-x)", "-cot(x)");
 
-        collect("sin(--x)", "sin(x)");
-        collect("arcsin(-x)", "arcsin(-x)");
+        collect(assert, "sin(--x)", "sin(x)");
+        collect(assert, "arcsin(-x)", "arcsin(-x)");
 
-        collect("sin(-x)cos(-x)", "-sin(x)cos(x)");
-        collect("sin(-x)/cos(-x)", "-tan(x)");
+        collect(assert, "sin(-x)cos(-x)", "-sin(x)cos(x)");
+        collect(assert, "sin(-x)/cos(-x)", "-tan(x)");
     });
 
-    test("collect then output tex", function() {
-        // user-friendly tex representation is not guaranteed after collect()
-        collect("-x", "-1x");
-        collecttex("-x", "-1x");
-        collect("a-b", "a+-1b");
-        collecttex("a-b", "a+-1b");
-        collect("a/b", "ab^-1");
-        collecttex("a/b", "ab^{-1}");
+    QUnit.test("collect then output tex", function(assert) {
+        // user-friendly tex representation is not guaranteed after collect(assert, )
+        collect(assert, "-x", "-1x");
+        collecttex(assert, "-x", "-1x");
+        collect(assert, "a-b", "a+-1b");
+        collecttex(assert, "a-b", "a+-1b");
+        collect(assert, "a/b", "ab^-1");
+        collecttex(assert, "a/b", "ab^{-1}");
     });
 
-    test("collect over an equation", function() {
+    QUnit.test("collect over an equation", function(assert) {
         // collect does not try to collect across both sides of an equation
-        collect("y+1-1=x*x", "y=x^(2)");
-        collect("1+y=1+x^2", "1+y=1+x^(2)");
+        collect(assert, "y+1-1=x*x", "y=x^(2)");
+        collect(assert, "1+y=1+x^2", "1+y=1+x^(2)");
     });
 
-    var simplify = function(input, reference) {
+    var simplify = function(assert, input, reference) {
         var actual = parse(input).simplify().normalize().print();
         var expected = parse(reference).normalize().print();
         var message = input + " simplifies as " + reference;
-        strictEqual(actual, expected, message);
+        assert.strictEqual(actual, expected, message);
     };
 
-    test("simplify", function() {
-        simplify("(a+b)^2", "(a+b)^2");
-        simplify("(a+b)(a+b)", "(a+b)^2");
+    QUnit.test("simplify", function(assert) {
+        simplify(assert, "(a+b)^2", "(a+b)^2");
+        simplify(assert, "(a+b)(a+b)", "(a+b)^2");
 
         // (ab)^2 ->[factor]-> a^2 * b^2 ->[collect]-> a^2 * b^2
         // (no change during collect, therefore factoring is rolled back)
-        simplify("(ab)^2", "(ab)^2");
+        simplify(assert, "(ab)^2", "(ab)^2");
 
         // (3x)^2 ->[factor]-> 3^2 * x^2 ->[collect]-> 9x^2
         // (changed during collect, therefore factoring persists)
-        simplify("(3x)^2", "9x^2");
+        simplify(assert, "(3x)^2", "9x^2");
 
-        simplify("(2sqrt(2))^4", "64");
-        simplify("(3sqrt[3]{3})^9", "531441");
+        simplify(assert, "(2sqrt(2))^4", "64");
+        simplify(assert, "(3sqrt[3]{3})^9", "531441");
 
         // from "Simplifying expressions with exponents"
-        simplify("((nx^5)^5)", "n^5 x^25");
-        simplify("((nx^5)^5)/2", "1/2 n^5 x^25");
-        simplify("((nx^5)^5)/(n^-2x^2)^-3", "n^-1 x^31");
+        simplify(assert, "((nx^5)^5)", "n^5 x^25");
+        simplify(assert, "((nx^5)^5)/2", "1/2 n^5 x^25");
+        simplify(assert, "((nx^5)^5)/(n^-2x^2)^-3", "n^-1 x^31");
 
-        simplify("1/(xya)+1/(xyb)", "1/(xya)+1/(xyb)");
+        simplify(assert, "1/(xya)+1/(xyb)", "1/(xya)+1/(xyb)");
 
         // Simplify rationals correctly
-        simplify("2*(x+1/3)", "2*x+2/3");
-        simplify("-1*(1/3+x)", "-1*x+-1/3");
+        simplify(assert, "2*(x+1/3)", "2*x+2/3");
+        simplify(assert, "-1*(1/3+x)", "-1*x+-1/3");
     });
 
     QUnit.module("units");
 
-    var unitEq = function(x, y, msg) {
-        ok(KAS.compare(x.simplify(), y.simplify()).equal, msg);
+    var unitEq = function(assert, x, y, msg) {
+        assert.ok(KAS.compare(x.simplify(), y.simplify()).equal, msg);
     };
 
-    var unitNeq = function(x, y, msg) {
-        ok(!KAS.compare(x.simplify(), y.simplify()).equal, msg);
+    var unitNeq = function(assert, x, y, msg) {
+        assert.ok(!KAS.compare(x.simplify(), y.simplify()).equal, msg);
     };
 
-    var parseEq = function(x, y, msg) {
-        unitEq(KAS.unitParse(x).expr, KAS.unitParse(y).expr, msg);
+    var parseEq = function(assert, x, y, msg) {
+        unitEq(assert, KAS.unitParse(x).expr, KAS.unitParse(y).expr, msg);
     };
 
-    var parseNeq = function(x, y, msg) {
-        unitNeq(KAS.unitParse(x).expr, KAS.unitParse(y).expr, msg);
+    var parseNeq = function(assert, x, y, msg) {
+        unitNeq(assert, KAS.unitParse(x).expr, KAS.unitParse(y).expr, msg);
     };
 
-    var solveUnitVariable = function(original, newUnit, expected) {
+    var solveUnitVariable = function(assert, original, newUnit, expected) {
         var originalParsed = KAS.unitParse(original).expr;
         var newUnitParsed = KAS.unitParse(newUnit).unit;
         var x = new KAS.Var("x");
@@ -1595,7 +1595,7 @@
         var answer = equality.solveLinearEquationForVariable(x);
 
         var msg = original + " = [" + expected.print() + "] " + newUnit;
-        ok(Math.round(answer.eval()) == Math.round(expected.eval()), msg);
+        assert.ok(Math.round(answer.eval()) == Math.round(expected.eval()), msg);
     };
 
     var formEq = function(x, y) {
@@ -1605,25 +1605,27 @@
         ).equal;
     };
 
-    var parseMagnitude = function(str, expected) {
+    var parseMagnitude = function(assert, str, expected) {
         var parsed = KAS.unitParse(str).coefficient;
-        ok(+parsed, expected);
+        assert.ok(+parsed, expected);
     };
 
-    test("simplify expressions with units", function() {
+    QUnit.test("simplify expressions with units", function(assert) {
         unitEq(
+            assert,
             new KAS.Mul(new KAS.Rational(1, 100), new KAS.Unit("cup")),
             new KAS.Mul(new KAS.Rational(1, 400), new KAS.Unit("qt")),
             "1/100 cup = 1 / 400 quart"
         );
 
-        parseEq("10 g", "0.01 kg", "10 g = 1 / 100 kg");
+        parseEq(assert, "10 g", "0.01 kg", "10 g = 1 / 100 kg");
 
-        parseEq("9.8 kg m / s^2", "9.8 N", "9.8 kg m / s^2 = 9.8 N");
+        parseEq(assert, "9.8 kg m / s^2", "9.8 N", "9.8 kg m / s^2 = 9.8 N");
 
-        parseEq("9.8 m / s^2", "9.8 N / kg", "9.8 m / s^2 = 9.8 N / kg");
+        parseEq(assert, "9.8 m / s^2", "9.8 N / kg", "9.8 m / s^2 = 9.8 N / kg");
 
         unitEq(
+            assert,
             new KAS.Mul(new KAS.Float(9.8),
                         new KAS.Unit("m"),
                         new KAS.Pow(new KAS.Unit("s"), new KAS.Int(-2))),
@@ -1634,6 +1636,7 @@
         );
 
         unitEq(
+            assert,
             new KAS.Mul(new KAS.Int(50),
                         new KAS.Unit("m"),
                         new KAS.Pow(new KAS.Unit("m"), new KAS.Int(-1))),
@@ -1648,6 +1651,7 @@
         // 1 tsp * ------ * ------- * ------ * -------
         //         3 tsp    16 tbsp   16 cup     gal
         unitEq(
+            assert,
             new KAS.Unit("tsp"),
             new KAS.Mul(
                 new KAS.Rational(1, 3),
@@ -1659,7 +1663,7 @@
             "tsp reduces"
         );
 
-        ok(
+        assert.ok(
             !KAS.compare(
                 new KAS.Mul(new KAS.Int(50), new KAS.Unit("m")),
                 new KAS.Int(50)
@@ -1667,27 +1671,28 @@
             "50 m != 50"
         );
 
-        parseNeq("50 m", "50 A", "50 m != 50 A");
-        parseEq("5000 mA", "5 A", "5000 mA = 5 A");
-        parseNeq("5 mA", "5 A", "5 mA != 5 A");
+        parseNeq(assert, "50 m", "50 A", "50 m != 50 A");
+        parseEq(assert, "5000 mA", "5 A", "5000 mA = 5 A");
+        parseNeq(assert, "5 mA", "5 A", "5 mA != 5 A");
 
-        parseNeq("9.8 kg m / s^2", "9.8 J", "9.8 kg m / s^2 != 9.8 J");
-        parseEq("9.8 kg m / s^2", "9.8 J/m", "9.8 kg m / s^2 = 9.8 J/m");
+        parseNeq(assert, "9.8 kg m / s^2", "9.8 J", "9.8 kg m / s^2 != 9.8 J");
+        parseEq(assert, "9.8 kg m / s^2", "9.8 J/m", "9.8 kg m / s^2 = 9.8 J/m");
 
-        ok(!formEq("mA", "A"), "mA !== A")
-        ok(!formEq("g", "kg"), "g !== kg");
-        ok(!formEq("kg m / s^2", "N"), "kg m / s^2 !== N");
-        ok(!formEq("m / s^2", "N / kg"), "m / s^2 !== N / kg");
+        assert.ok(!formEq("mA", "A"), "mA !== A")
+        assert.ok(!formEq("g", "kg"), "g !== kg");
+        assert.ok(!formEq("kg m / s^2", "N"), "kg m / s^2 !== N");
+        assert.ok(!formEq("m / s^2", "N / kg"), "m / s^2 !== N / kg");
 
-        ok(formEq("A", "A"), "A === A");
-        ok(formEq("kg", "kg"), "kg = kg");
-        ok(formEq("kg m / s^2", "m kg / s^2"), "kg m / s^2 === m kg / s^2");
-        ok(formEq("m / s^2", "m / s^2"), "m / s^2 === m / s^2");
+        assert.ok(formEq("A", "A"), "A === A");
+        assert.ok(formEq("kg", "kg"), "kg = kg");
+        assert.ok(formEq("kg m / s^2", "m kg / s^2"), "kg m / s^2 === m kg / s^2");
+        assert.ok(formEq("m / s^2", "m / s^2"), "m / s^2 === m / s^2");
 
         // btu doesn't allow si prefixes
-        throws(new KAS.Unit("mBTU"), "mBTU throws");
+        assert.throws(new KAS.Unit("mBTU"), "mBTU throws");
 
         solveUnitVariable(
+            assert,
             "2.5 gal", "cup", new KAS.Int(40)
         );
 
@@ -1695,189 +1700,194 @@
         // 1 tsp * ------ * ------- * ------ * -------- * ------ * (--------)
         //         3 tsp    16 tbsp   16 cup   1000 gal   1000 L   (    m   )
         solveUnitVariable(
+            assert,
             "1 tsp", "cm^3", new KAS.Rational(3785, 768)
         );
 
         solveUnitVariable(
+            assert,
             "1 dozen qt", "gal", new KAS.Int(3)
         );
 
         solveUnitVariable(
+            assert,
             "1 day", "sec", new KAS.Int(60*60*24)
         );
 
         solveUnitVariable(
+            assert,
             "5 kg m / s^2", "N", new KAS.Int(5)
         );
 
         // This was originally broken due to a scientific notation parsing
         // problem. Leaving it around because it doesn't hurt anything.
         solveUnitVariable(
+            assert,
             "5 x 10^5 N", "lb", new KAS.Int(112404)
         );
 
-        parseMagnitude("5 x 10^5 N", 500000);
-        parseMagnitude("1.23456 x 10^5 N", 123456);
-        parseMagnitude("3.14 x 10^-2 N", 0.0314);
+        parseMagnitude(assert, "5 x 10^5 N", 500000);
+        parseMagnitude(assert, "1.23456 x 10^5 N", 123456);
+        parseMagnitude(assert, "3.14 x 10^-2 N", 0.0314);
     });
 
     QUnit.module("isSimplified");
 
-    var isSimplified = function(input, expectedResult, options) {
+    var isSimplified = function(assert, input, expectedResult, options) {
         if (expectedResult === undefined) expectedResult = true;
         var message = input + (expectedResult ? " is " : " is NOT ") + "simplified";
-        ok(parse(input, options).isSimplified() === expectedResult, message);
+        assert.ok(parse(input, options).isSimplified() === expectedResult, message);
     };
 
-    test("isSimplified (addition/subtraction)", function() {
-        isSimplified("a+b+c");
-        isSimplified("a-b-c");
-        isSimplified("a+b+c+c", false);
-        isSimplified("a-b-c-d-d+d", false);
-        isSimplified("x");
-        isSimplified("x+0", false);
+    QUnit.test("isSimplified (addition/subtraction)", function(assert) {
+        isSimplified(assert, "a+b+c");
+        isSimplified(assert, "a-b-c");
+        isSimplified(assert, "a+b+c+c", false);
+        isSimplified(assert, "a-b-c-d-d+d", false);
+        isSimplified(assert, "x");
+        isSimplified(assert, "x+0", false);
     });
 
-    test("isSimplified (multiplication/division/negation)", function() {
-        isSimplified("1/2");
-        isSimplified("2/1", false);
-        isSimplified("(2x)/(5x)", false);
-        isSimplified("-x");
-        isSimplified("-1*x");
-        isSimplified("--x", false);
-        isSimplified("x/1", false);
-        isSimplified("x/y");
-        isSimplified("xy/z");
-        isSimplified("-3x");
-        isSimplified("-x*3");
-        isSimplified("-x*3*y");
-        isSimplified("(x+1)/(2(x+1))", false);
+    QUnit.test("isSimplified (multiplication/division/negation)", function(assert) {
+        isSimplified(assert, "1/2");
+        isSimplified(assert, "2/1", false);
+        isSimplified(assert, "(2x)/(5x)", false);
+        isSimplified(assert, "-x");
+        isSimplified(assert, "-1*x");
+        isSimplified(assert, "--x", false);
+        isSimplified(assert, "x/1", false);
+        isSimplified(assert, "x/y");
+        isSimplified(assert, "xy/z");
+        isSimplified(assert, "-3x");
+        isSimplified(assert, "-x*3");
+        isSimplified(assert, "-x*3*y");
+        isSimplified(assert, "(x+1)/(2(x+1))", false);
     });
 
-    test("isSimplified (exponentiation)", function() {
-        isSimplified("x^-1");
-        isSimplified("1/x");
-        isSimplified("1/x^-1", false);
+    QUnit.test("isSimplified (exponentiation)", function(assert) {
+        isSimplified(assert, "x^-1");
+        isSimplified(assert, "1/x");
+        isSimplified(assert, "1/x^-1", false);
     });
 
-    test("isSimplified (logarithms)", function() {
-        isSimplified("ln(x)");
-        isSimplified("ln(x+y)");
+    QUnit.test("isSimplified (logarithms)", function(assert) {
+        isSimplified(assert, "ln(x)");
+        isSimplified(assert, "ln(x+y)");
 
         // Will only expand logarithms if leads to a simpler expression
-        // TODO(alex): Combine all simplify() and isSimplified() tests!
-        isSimplified("ln(x/y)");
-        isSimplified("ln(x/y)+ln(y)", false);
+        // TODO(alex): Combine all simplify(assert, ) and isSimplified(assert, ) tests!
+        isSimplified(assert, "ln(x/y)");
+        isSimplified(assert, "ln(x/y)+ln(y)", false);
     });
 
-    test("isSimplified (equations)", function() {
-        isSimplified("x=10");
-        isSimplified("x=-10");
-        isSimplified("x=10y");
-        isSimplified("x=-10y");
-        isSimplified("x=10+y");
-        isSimplified("x=-10+y");
+    QUnit.test("isSimplified (equations)", function(assert) {
+        isSimplified(assert, "x=10");
+        isSimplified(assert, "x=-10");
+        isSimplified(assert, "x=10y");
+        isSimplified(assert, "x=-10y");
+        isSimplified(assert, "x=10+y");
+        isSimplified(assert, "x=-10+y");
 
-        isSimplified("f(2x) = 10", true, {functions: ["f"]});
-        isSimplified("f(x+x) = 10", false, {functions: ["f"]});
+        isSimplified(assert, "f(2x) = 10", true, {functions: ["f"]});
+        isSimplified(assert, "f(x+x) = 10", false, {functions: ["f"]});
     });
 
-    test("isSimplified (equalities)", function() {
-        isSimplified("y=x");
-        isSimplified("y=x^2");
-        isSimplified("y=x*x", false);
+    QUnit.test("isSimplified (equalities)", function(assert) {
+        isSimplified(assert, "y=x");
+        isSimplified(assert, "y=x^2");
+        isSimplified(assert, "y=x*x", false);
 
-        isSimplified("y=x^2+1");
-        isSimplified("xy=x^2+1");
-        isSimplified("y+1=x^2+1", false);
+        isSimplified(assert, "y=x^2+1");
+        isSimplified(assert, "xy=x^2+1");
+        isSimplified(assert, "y+1=x^2+1", false);
 
-        isSimplified("xy=x^2", false);
-        isSimplified("x^2y=x^3", false);
-        isSimplified("alnx=blnx+clnx", false)
+        isSimplified(assert, "xy=x^2", false);
+        isSimplified(assert, "x^2y=x^3", false);
+        isSimplified(assert, "alnx=blnx+clnx", false)
 
-        isSimplified("xy=0");
-        isSimplified("2xy=0", false);
-        isSimplified("xy/z=0");
+        isSimplified(assert, "xy=0");
+        isSimplified(assert, "2xy=0", false);
+        isSimplified(assert, "xy/z=0");
     });
 
-    test("isSimplified (inequalities)", function() {
-        isSimplified("y<x");
-        isSimplified("y<x^2");
-        isSimplified("y<x*x", false);
+    QUnit.test("isSimplified (inequalities)", function(assert) {
+        isSimplified(assert, "y<x");
+        isSimplified(assert, "y<x^2");
+        isSimplified(assert, "y<x*x", false);
 
-        isSimplified("y<x^2+1");
-        isSimplified("xy<x^2+1");
-        isSimplified("y+1<x^2+1", false);
+        isSimplified(assert, "y<x^2+1");
+        isSimplified(assert, "xy<x^2+1");
+        isSimplified(assert, "y+1<x^2+1", false);
 
-        isSimplified("xy<x^2"); // x might be negative
-        isSimplified("x^2y<x^3", false);
-        isSimplified("alnx<blnx+clnx"); // lnx might be negative
+        isSimplified(assert, "xy<x^2"); // x might be negative
+        isSimplified(assert, "x^2y<x^3", false);
+        isSimplified(assert, "alnx<blnx+clnx"); // lnx might be negative
 
-        isSimplified("xy<0");
-        isSimplified("2xy<0", false);
-        isSimplified("xy/z<0");
+        isSimplified(assert, "xy<0");
+        isSimplified(assert, "2xy<0", false);
+        isSimplified(assert, "xy/z<0");
     });
 
-    test("isSimplified (rational expressions)", function() {
-        isSimplified("3/4 x");
-        isSimplified("3/(4x)");
-        isSimplified("3/4 1/x");
+    QUnit.test("isSimplified (rational expressions)", function(assert) {
+        isSimplified(assert, "3/4 x");
+        isSimplified(assert, "3/(4x)");
+        isSimplified(assert, "3/4 1/x");
 
-        isSimplified("(x+1)/(x+2)");
-        isSimplified("(x+1)/(2x+2)", false);
-        isSimplified("(2x+2)/(x+1)", false);
+        isSimplified(assert, "(x+1)/(x+2)");
+        isSimplified(assert, "(x+1)/(2x+2)", false);
+        isSimplified(assert, "(2x+2)/(x+1)", false);
 
-        isSimplified("xy+2y=x+1");
-        isSimplified("y=(x+1)/(x+2)");
-        isSimplified("y/(x+1)=1/(x+2)");
+        isSimplified(assert, "xy+2y=x+1");
+        isSimplified(assert, "y=(x+1)/(x+2)");
+        isSimplified(assert, "y/(x+1)=1/(x+2)");
 
-        // TODO(alex): Combine all isSimplified() and simplify() tests!
-        isSimplified("y=(x+1)/(2x+2)", false);
-        isSimplified("y=1/2");
+        // TODO(alex): Combine all isSimplified(assert, ) and simplify(assert, ) tests!
+        isSimplified(assert, "y=(x+1)/(2x+2)", false);
+        isSimplified(assert, "y=1/2");
 
-        isSimplified("y=(2x+2)/(x+1)", false);
-        isSimplified("y=2");
+        isSimplified(assert, "y=(2x+2)/(x+1)", false);
+        isSimplified(assert, "y=2");
 
         // same denominators (adding_and_subtracting_rational_expressions_1.5)
-        isSimplified("(15np-25mp)/(15p^2-5p)+(20mp+10p^2)/(15p^2-5p)", false);
-        isSimplified("(3n-m+2p)/(3p-1)");
+        isSimplified(assert, "(15np-25mp)/(15p^2-5p)+(20mp+10p^2)/(15p^2-5p)", false);
+        isSimplified(assert, "(3n-m+2p)/(3p-1)");
 
-        isSimplified("5yx/(2x^2+4yx)-(2x^2-6yx)/(2x^2+4yx)", false);
-        isSimplified("(11y-2x)/(2x+4y)");
+        isSimplified(assert, "5yx/(2x^2+4yx)-(2x^2-6yx)/(2x^2+4yx)", false);
+        isSimplified(assert, "(11y-2x)/(2x+4y)");
 
-        isSimplified("(25m^2-20pm)/(5pm+5m)-20m^2/(5pm+5m)", false);
-        isSimplified("(m-4p)/(p+1)");
+        isSimplified(assert, "(25m^2-20pm)/(5pm+5m)-20m^2/(5pm+5m)", false);
+        isSimplified(assert, "(m-4p)/(p+1)");
 
         // pathological examples
-        isSimplified("  (a + b)/(2c+2d)");
-        isSimplified("  (3a+3b)/(2c+2d)");
-        isSimplified("  (2a+2b)/( c+ d)");
-        isSimplified("  (2a+2b)/(3c+3d)");
-        isSimplified("  (2a+2b)/(4c+4d)", false);
-        isSimplified("  (4a+4b)/(2c+2d)", false);
-        isSimplified("y=(a + b)/(2c+2d)");
-        isSimplified("y=(3a+3b)/(2c+2d)");
-        isSimplified("y=(2a+2b)/( c+ d)");
-        isSimplified("y=(2a+2b)/(3c+3d)");
-        isSimplified("y=(2a+2b)/(4c+4d)", false);
-        isSimplified("y=(4a+4b)/(2c+2d)", false);
+        isSimplified(assert, "  (a + b)/(2c+2d)");
+        isSimplified(assert, "  (3a+3b)/(2c+2d)");
+        isSimplified(assert, "  (2a+2b)/( c+ d)");
+        isSimplified(assert, "  (2a+2b)/(3c+3d)");
+        isSimplified(assert, "  (2a+2b)/(4c+4d)", false);
+        isSimplified(assert, "  (4a+4b)/(2c+2d)", false);
+        isSimplified(assert, "y=(a + b)/(2c+2d)");
+        isSimplified(assert, "y=(3a+3b)/(2c+2d)");
+        isSimplified(assert, "y=(2a+2b)/( c+ d)");
+        isSimplified(assert, "y=(2a+2b)/(3c+3d)");
+        isSimplified(assert, "y=(2a+2b)/(4c+4d)", false);
+        isSimplified(assert, "y=(4a+4b)/(2c+2d)", false);
     });
 
-    var hasConsts = function(input, expectedConsts, options) {
-        deepEqual(parse(input, options).getConsts(), expectedConsts);
+    var hasConsts = function(assert, input, expectedConsts, options) {
+        assert.deepEqual(parse(input, options).getConsts(), expectedConsts);
     };
 
-    test("getConsts", function() {
-        hasConsts("4", []);
-        hasConsts("4x", []);
-        hasConsts("4pi", ["pi"]);
-        hasConsts("4e", ["e"]);
-        hasConsts("4pi+e", ["e", "pi"]);
-        hasConsts("4pi+pi", ["pi"]);
-        hasConsts("4cos(pi)", ["pi"]);
-        hasConsts("4cos(xpi)", ["pi"]);
-        hasConsts("(4x)/(2pi)", ["pi"]);
-        hasConsts("4sec(x)", []);
+    QUnit.test("getConsts", function(assert) {
+        hasConsts(assert, "4", []);
+        hasConsts(assert, "4x", []);
+        hasConsts(assert, "4pi", ["pi"]);
+        hasConsts(assert, "4e", ["e"]);
+        hasConsts(assert, "4pi+e", ["e", "pi"]);
+        hasConsts(assert, "4pi+pi", ["pi"]);
+        hasConsts(assert, "4cos(pi)", ["pi"]);
+        hasConsts(assert, "4cos(xpi)", ["pi"]);
+        hasConsts(assert, "(4x)/(2pi)", ["pi"]);
+        hasConsts(assert, "4sec(x)", []);
     });
 })(KAS);
 </script>


### PR DESCRIPTION
There are security vulnerabilities in the earlier versions of these
modules. The QUnit change required massive changes to the test file
(asserts are no longer global). I was able to get most everything
working, but there are a few tests that still fail. There are failing
tests in master though, so...

The only not-completely-trivial change is to some rounding in hyperbolic expressions (lines 755-757) and changing how the `close` addon is sourced.