### PR TITLE
Use NPM scripts to run grunt; don't require it be installed globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ expr.simplify().print();
 How to build the library
 ------------------------
     npm install
-    grunt
+    npm run build
 
 How to build the parser
 -----------------------
 First, make any changes in `src/parser-generator.js`
 
     npm install
-    grunt parser
+    npm run build:parser
 
 License
 -------

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A lightweight JavaScript CAS for comparing expressions and equations.",
   "main": "build/kas.js",
   "scripts": {
-    "test": "node testrunner"
+    "test": "node testrunner",
+    "build": "grunt",
+    "build:parser": "grunt parser"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Summary:
The Readme describes how to build the library and parser, which assumes you have grunt installed globally... which isn't necessary because it is a devDependency.  Switch to using `npm run` to avoid installing grunt globally.

Test Plan:
npm run build
npm run build:parser
