### PR TITLE
Change expression widget's sameForm method to use .tex()

### DIFF
--- a/kas.js
+++ b/kas.js
@@ -1936,11 +1936,9 @@ _.extend(Expr.prototype, {
     },
 
     // check that the structure of both expressions is the same
-    // all negative signs are stripped and the expressions are converted to
-    // a canonical commutative form
     // should only be done after compare() returns true to avoid false positives
     sameForm: function(other) {
-        return this.strip().equals(other.strip());
+        return this.tex() === other.tex();
     },
 
     // returns the GCD of this expression and the given factor

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kas",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A lightweight JavaScript CAS for comparing expressions and equations.",
   "main": "build/kas.js",
   "scripts": {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -403,11 +403,9 @@ _.extend(Expr.prototype, {
     },
 
     // check that the structure of both expressions is the same
-    // all negative signs are stripped and the expressions are converted to
-    // a canonical commutative form
     // should only be done after compare() returns true to avoid false positives
     sameForm: function(other) {
-        return this.strip().equals(other.strip());
+        return this.tex() === other.tex();
     },
 
     // returns the GCD of this expression and the given factor


### PR DESCRIPTION
In the Khan Academy web app, we have two exercises that require the answer given by the user to be in a specific form. One of those exercises is working. The other is not.

I'm not totally clear on the specifics of how KaTex works, but for the exercise that is not working, the parsed form looks the same no matter what format the answer is in. That means that no matter what form the answer is in, it's always passing the form comparison. The `sameForm` method is currently taking the parsed expression and calling `.strip()`. Changing it to use `.tex()` makes the form comparison work for both exercises. (If you'd like to hear more about the format each method gives for questions for the two exercises, I'm happy to dump a bunch of that here for your perusal.)

This change should not affect exercises that don't care what form the answer is in. Only these two exercises are known to use that option.

Test plan:
I made this change in the webapp repo in third_party/javascript-khansrc/kas,
navigate to both `/math/algebra2/x2ec2f6f830c9fb89:exp/x2ec2f6f830c9fb89:rational-exp/e/understanding-fractional-exponents` and `/math/algebra2/x2ec2f6f830c9fb89:exp/x2ec2f6f830c9fb89:rational-exp/e/exponents_3`,
did a bunch of questions where I first copied the question format then used the format they were looking for,
and verified that the question format was considered incorrect and the expected format was considered correct.